### PR TITLE
Bugfixes: event location not specified, or online-only

### DIFF
--- a/functions/scraping-events/src/scraping_events/schemas.py
+++ b/functions/scraping-events/src/scraping_events/schemas.py
@@ -13,7 +13,7 @@ class Event(BaseModel):
     title: str
     description: str
     time: AwareDatetime
-    venue_name: str
+    venue_name: str | None
     venue_url: str | None
     venue_address: str | None
     image_url: str | None

--- a/functions/scraping-events/src/scraping_events/schemas.py
+++ b/functions/scraping-events/src/scraping_events/schemas.py
@@ -15,7 +15,7 @@ class Event(BaseModel):
     time: AwareDatetime
     venue_name: str
     venue_url: str | None
-    venue_address: str
+    venue_address: str | None
     image_url: str | None
 
 

--- a/functions/scraping-events/src/scraping_events/scrape_meetup.py
+++ b/functions/scraping-events/src/scraping_events/scrape_meetup.py
@@ -66,6 +66,7 @@ async def _get_event_details(page_wrapper: PageWrapper, event_url: str) -> Event
     if (await page.get_by_test_id("attend-irl-btn").count()) > 0:
         venue_name_link = page.get_by_test_id("venue-name-link")
         venue_name = await venue_name_link.inner_text()
+        venue_name = venue_name.strip()
         for venue_location_link in (venue_name_link, page.get_by_test_id("map-link")):
             venue_url = await venue_location_link.get_attribute("href")
             if venue_url:
@@ -76,6 +77,11 @@ async def _get_event_details(page_wrapper: PageWrapper, event_url: str) -> Event
         venue_address = re.sub(r"\s*·\s*", ", ", venue_address).strip()
     elif (await page.get_by_test_id("attend-online-btn").count()) > 0:
         venue_name = await page.get_by_test_id("venue-name-value").inner_text()
+        venue_name = venue_name.strip()
+        venue_url = None
+        venue_address = None
+    elif (await page.get_by_test_id("needs-location").count()) > 0:
+        venue_name = None
         venue_url = None
         venue_address = None
     else:
@@ -90,7 +96,7 @@ async def _get_event_details(page_wrapper: PageWrapper, event_url: str) -> Event
         title=event_title,
         description=event_description,
         time=event_time,
-        venue_name=venue_name.strip(),
+        venue_name=venue_name,
         venue_url=venue_url,
         venue_address=venue_address,
         image_url=image_url,

--- a/functions/scraping-events/src/scraping_events/scrape_meetup.py
+++ b/functions/scraping-events/src/scraping_events/scrape_meetup.py
@@ -63,17 +63,23 @@ async def _get_event_details(page_wrapper: PageWrapper, event_url: str) -> Event
         raise ParsingError(f"Failed to get event time from {event_url}")
     event_time = _parse_timestamp(event_time_str)
     # venue
-    venue_name_link = page.get_by_test_id("venue-name-link")
-    venue_name = await venue_name_link.inner_text()
-    venue_name = venue_name.strip()
-    for venue_location_link in (venue_name_link, page.get_by_test_id("map-link")):
-        venue_url = await venue_location_link.get_attribute("href")
-        if venue_url:
-            break
-    else:  # never hit break
-        LOGGER.warning(f"Failed to find venue URL for event at {event_url}")
-    venue_address = await page.get_by_test_id("location-info").inner_text()
-    venue_address = re.sub(r"\s*·\s*", ", ", venue_address).strip()
+    if (await page.get_by_test_id("attend-irl-btn").count()) > 0:
+        venue_name_link = page.get_by_test_id("venue-name-link")
+        venue_name = await venue_name_link.inner_text()
+        for venue_location_link in (venue_name_link, page.get_by_test_id("map-link")):
+            venue_url = await venue_location_link.get_attribute("href")
+            if venue_url:
+                break
+        else:  # never hit break
+            LOGGER.warning(f"Failed to find venue URL for event at {event_url}")
+        venue_address = await page.get_by_test_id("location-info").inner_text()
+        venue_address = re.sub(r"\s*·\s*", ", ", venue_address).strip()
+    elif (await page.get_by_test_id("attend-online-btn").count()) > 0:
+        venue_name = await page.get_by_test_id("venue-name-value").inner_text()
+        venue_url = None
+        venue_address = None
+    else:
+        raise ParsingError(f"Failed to identify venue for event at {event_url}")
     # image
     image_url = await page.get_by_test_id("event-description-image").locator("img").get_attribute("src")
     if not image_url:
@@ -84,7 +90,7 @@ async def _get_event_details(page_wrapper: PageWrapper, event_url: str) -> Event
         title=event_title,
         description=event_description,
         time=event_time,
-        venue_name=venue_name,
+        venue_name=venue_name.strip(),
         venue_url=venue_url,
         venue_address=venue_address,
         image_url=image_url,


### PR DESCRIPTION
Summary:
- Allow for online-only events (e.g. https://www.meetup.com/utahjs/events/305911711/)
- Allow for no-location events (e.g. https://www.meetup.com/utah-zig/events/307581553/)

NOTE: These changes include a loosening of the schema for responses! `venue_name` and `venue_address` are now both nullable
