### PR TITLE
fix: hybrid event venue classification and online-only detection

### DIFF
--- a/.github/workflows/weekly-meetup-smoke-test.yml
+++ b/.github/workflows/weekly-meetup-smoke-test.yml
@@ -32,15 +32,15 @@ jobs:
       - name: Install Playwright browsers
         run: uv run playwright install chromium --with-deps
 
-      - name: Run smoke tests (group URL)
+      - name: Run typed URL smoke tests
         env:
-          SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_GROUP_URL }}
-        run: uv run pytest tests/smoke/ -v --tb=short
-
-      - name: Run smoke tests (event URL)
-        env:
-          SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_EVENT_URL }}
-        run: uv run pytest tests/smoke/ -v --tb=short
+          GROUP_URL: ${{ secrets.SMOKE_TEST_GROUP_URL }}
+          EVENT_URL: ${{ secrets.SMOKE_TEST_EVENT_URL }}
+          ONLINE_ONLY_EVENT_URL: ${{ secrets.SMOKE_TEST_ONLINE_ONLY_EVENT_URL }}
+          HYBRID_EVENT_URL: ${{ secrets.SMOKE_TEST_HYBRID_EVENT_URL }}
+          IN_PERSON_EVENT_URL: ${{ secrets.SMOKE_TEST_IN_PERSON_EVENT_URL }}
+          GROUP_EVENTS_PAGE_URL: ${{ secrets.SMOKE_TEST_GROUP_EVENTS_PAGE_URL }}
+        run: uv run pytest tests/smoke/test_meetup_local_urls.py -v --tb=short
 
   claude-fix:
     runs-on: ubuntu-latest

--- a/functions/scraping-events/.env.local.example
+++ b/functions/scraping-events/.env.local.example
@@ -1,0 +1,20 @@
+# Copy this file to .env.local and fill in real URLs for local smoke testing.
+# .env.local is git-ignored; this file is committed as a template.
+
+# A Meetup group page (e.g. meetup.com/utahjs/)
+GROUP_URL=
+
+# A specific upcoming event (non-recurring)
+EVENT_URL=
+
+# An online-only event
+ONLINE_ONLY_EVENT_URL=
+
+# A hybrid event (both IRL and online attendance options)
+HYBRID_EVENT_URL=
+
+# An in-person event
+IN_PERSON_EVENT_URL=
+
+# The group's events listing page (e.g. meetup.com/group/events/)
+GROUP_EVENTS_PAGE_URL=

--- a/functions/scraping-events/.gitignore
+++ b/functions/scraping-events/.gitignore
@@ -1,4 +1,5 @@
 /traces/
+smoke-results.json
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -131,6 +132,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.local
 .venv
 env/
 venv/

--- a/functions/scraping-events/src/scraping_events/scrape_meetup.py
+++ b/functions/scraping-events/src/scraping_events/scrape_meetup.py
@@ -20,9 +20,12 @@ def is_meetup_url(url_parsed: ParsedUrl) -> bool:
 
 
 def _extract_group_url(url: str) -> str | None:
-    """If url is an event URL, return the group base URL. Otherwise return None."""
+    """If url is a specific event URL, return the group base URL. Otherwise return None.
+
+    Matches /group-slug/events/12345 but not /group-slug/events/ (which is a group listing page).
+    """
     parsed = urlparse(url)
-    match = re.match(r"(/[^/]+)/events/", parsed.path)
+    match = re.match(r"(/[^/]+)/events/\d+", parsed.path)
     if match:
         return f"{parsed.scheme}://{parsed.netloc}{match.group(1)}/"
     return None
@@ -51,7 +54,8 @@ async def _get_upcoming_event_urls(page_wrapper: PageWrapper, starting_url: str,
             return [starting_url]
         LOGGER.info(f"Recurring event URL normalised to group URL: {starting_url} -> {group_url}")
     else:
-        group_url = starting_url
+        # Normalise a group events listing URL (e.g. meetup.com/group/events/) to the group base URL
+        group_url = re.sub(r"/events/?$", "/", starting_url)
 
     LOGGER.info(f"Looking for upcoming events listed on {group_url}")
     await page_wrapper.navigate(group_url)
@@ -145,7 +149,7 @@ async def _get_event_details(page_wrapper: PageWrapper, event_url: str) -> Event
     is_online = (await page.get_by_test_id("attend-online-btn").count()) > 0 or event_type == "ONLINE"
     no_location = (await page.get_by_test_id("needs-location").count()) > 0
 
-    if is_irl and not is_online:
+    if is_irl:
         venue_data = next_event_data.get("venue") or {}
         venue_name = (venue_data.get("name") or "").strip() or None
         addr_parts = [venue_data.get("address", ""), venue_data.get("city", ""), (venue_data.get("state") or "").upper()]

--- a/functions/scraping-events/tests/smoke/test_meetup_local_urls.py
+++ b/functions/scraping-events/tests/smoke/test_meetup_local_urls.py
@@ -1,0 +1,140 @@
+"""
+Smoke tests for each URL type defined in .env.local or environment variables.
+
+URL variables are resolved in priority order: environment variables first, then
+.env.local. This lets CI inject secrets without needing the file on disk.
+
+Run all local URL tests:
+    cd functions/scraping-events
+    DEBUG=false uv run pytest tests/smoke/test_meetup_local_urls.py -v
+
+Run a single URL type:
+    DEBUG=false uv run pytest tests/smoke/test_meetup_local_urls.py -v -k hybrid
+
+Override a single URL via env:
+    HYBRID_EVENT_URL=<url> DEBUG=false uv run pytest tests/smoke/test_meetup_local_urls.py -v -k hybrid
+"""
+
+import json
+import os
+import subprocess
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from dotenv import dotenv_values
+
+# functions/scraping-events/ — parents[0]=smoke/, parents[1]=tests/, parents[2]=scraping-events/
+_SCRAPING_DIR = Path(__file__).parents[2]
+
+_LOCAL_ENV_FILE = _SCRAPING_DIR / ".env.local"
+
+# Each entry is (var_name, expected_venue_type, min_events).
+# expected_venue_type drives type-specific assertions:
+#   "physical"  — every returned event must have a venue_address
+#   "online"    — if a single event is returned, it must have no venue_address/venue_url
+#   None        — no venue-type assertion (group/mixed results)
+# min_events: minimum number of events expected (0 = no minimum enforced)
+_URL_VARS: list[tuple[str, str | None, int]] = [
+    ("GROUP_URL", None, 0),
+    ("EVENT_URL", None, 1),
+    ("ONLINE_ONLY_EVENT_URL", "online", 0),
+    ("HYBRID_EVENT_URL", "physical", 1),
+    ("IN_PERSON_EVENT_URL", "physical", 1),
+    ("GROUP_EVENTS_PAGE_URL", None, 0),
+]
+
+
+def _load_urls() -> list[tuple[str, str, str | None, int]]:
+    """Return [(var_name, url, expected_venue_type, min_events), ...] for every non-empty URL.
+
+    Environment variables take precedence over .env.local so CI secrets work without
+    a file on disk.
+    """
+    file_env = dotenv_values(_LOCAL_ENV_FILE) if _LOCAL_ENV_FILE.exists() else {}
+    result = []
+    for var, expected_type, min_events in _URL_VARS:
+        url = os.environ.get(var) or file_env.get(var) or ""
+        if url:
+            result.append((var, url, expected_type, min_events))
+    return result
+
+
+def _run_cli(url: str, max_events: int = 5) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["uv", "run", "python", "-m", "scraping_events.main_cli", url, "--max-events", str(max_events)],
+        capture_output=True,
+        text=True,
+        cwd=_SCRAPING_DIR,
+        env={**os.environ, "DEBUG": "false"},
+    )
+
+
+def _assert_event_fields(event: dict) -> None:
+    """Assert that an event has all 8 schema fields with valid non-nullable values."""
+    required_keys = {"url", "title", "description", "time", "venue_name", "venue_url", "venue_address", "image_url"}
+    missing = required_keys - set(event.keys())
+    assert not missing, f"Event missing fields: {missing}"
+
+    assert event["url"], "event.url must be non-empty"
+    assert event["url"].startswith("https://"), f"event.url must start with https://, got: {event['url']!r}"
+    assert event["title"], "event.title must be non-empty"
+    assert event["time"], "event.time must be non-null"
+
+    parsed = datetime.fromisoformat(event["time"])
+    assert parsed.tzinfo is not None, f"event.time must be timezone-aware, got: {event['time']!r}"
+
+
+def _param_id(var_name: str) -> str:
+    return var_name.lower().replace("_url", "").replace("_", "-")
+
+
+_loaded_urls = _load_urls()
+
+_params = [
+    pytest.param(url, expected_type, min_events, id=_param_id(var))
+    for var, url, expected_type, min_events in _loaded_urls
+]
+
+
+@pytest.mark.smoke
+@pytest.mark.skipif(not _loaded_urls, reason=".env.local not found or no URLs set")
+@pytest.mark.parametrize("url,expected_venue_type,min_events", _params)
+def test_scraper_returns_valid_events(url: str, expected_venue_type: str | None, min_events: int) -> None:
+    """Scrape a URL, validate event structure, and assert correct venue classification."""
+    result = _run_cli(url)
+
+    assert result.returncode == 0, (
+        f"CLI exited {result.returncode}\nstdout: {result.stdout}\nstderr: {result.stderr}"
+    )
+
+    data = json.loads(result.stdout)
+    assert "events" in data, f"Expected 'events' key in response, got: {list(data.keys())}"
+    events: list[dict] = data["events"]
+    assert isinstance(events, list)
+
+    if min_events:
+        assert len(events) >= min_events, f"Expected >= {min_events} events, got {len(events)}"
+
+    for event in events:
+        _assert_event_fields(event)
+
+    # Type-specific venue assertions
+    if expected_venue_type == "physical":
+        # Every event from a physical/hybrid URL must have a venue_address.
+        # This catches the bug where hybrid events were stored as online-only.
+        for event in events:
+            assert event.get("venue_address"), (
+                f"Expected a physical venue_address for {url!r}, "
+                f"but got venue_address={event.get('venue_address')!r} for {event['title']!r}"
+            )
+
+    if expected_venue_type == "online" and len(events) == 1:
+        # Only assert venue type when the URL returned a single event (non-recurring).
+        # Recurring online-only events redirect to the group page and return a mixed list.
+        event = events[0]
+        assert event.get("venue_address") is None and event.get("venue_url") is None, (
+            f"Expected online-only venue for {url!r}, "
+            f"but got venue_address={event.get('venue_address')!r}, "
+            f"venue_url={event.get('venue_url')!r} for {event['title']!r}"
+        )

--- a/lib/locationUtils.ts
+++ b/lib/locationUtils.ts
@@ -89,7 +89,7 @@ export function categorizeEventByRegion(event: Record<string, any>): UtahRegion 
   return 'Unknown';
 }
 
-export function isOnlineEvent(event: Record<string, any>): boolean {
+export function isOnlineOnlyEvent(event: Record<string, any>): boolean {
   // Prefer venue/location fields as stronger signals for in-person vs online
   const venueText = [event.location, event.venue_name].filter(Boolean).join(' ').toLowerCase();
   const contentText = [event.description, event.title].filter(Boolean).join(' ').toLowerCase();
@@ -112,6 +112,10 @@ export function isOnlineEvent(event: Record<string, any>): boolean {
     const hasPhysical = /\d{1,5}\s+\w+/.test(venueText) || /\b(street|st\.|avenue|ave\.|road|rd\.|lane|ln\.|drive|dr\.)\b/i.test(venueText);
     if (hasPhysical) return false;
   }
+
+  // A populated city or postal_code is an unambiguous physical presence signal —
+  // don't let a URL in the description override it.
+  if (event.city || event.postal_code) return false;
 
   // If no venue/location signals, consider title/description but use stricter matching
   if (contentText) {

--- a/src/components/EventStats.tsx
+++ b/src/components/EventStats.tsx
@@ -2,7 +2,7 @@ import { Calendar, Users, Database, TrendingUp, Globe, Building2 } from "lucide-
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Event, Group } from "@/types/events";
-import { isOnlineEvent } from "../../lib/locationUtils";
+import { isOnlineOnlyEvent } from "../../lib/locationUtils";
 
 
 interface EventStatsProps {
@@ -50,7 +50,7 @@ export const EventStats = ({ events, groups, filteredCount, hasActiveFilters = f
   });
 
   // Calculate online vs in-person events
-  const onlineEvents = events.filter(event => isOnlineEvent(event)).length;
+  const onlineEvents = events.filter(event => isOnlineOnlyEvent(event)).length;
   const inPersonEvents = totalEvents - onlineEvents;
 
 

--- a/src/hooks/useEventFiltering.ts
+++ b/src/hooks/useEventFiltering.ts
@@ -2,7 +2,7 @@
 import { useMemo } from "react";
 import { parseISO, isSameDay, startOfToday } from "date-fns";
 import { Event, Group, UtahRegion } from "@/types/events";
-import { categorizeEventByRegion, isOnlineEvent } from "../../lib/locationUtils";
+import { categorizeEventByRegion, isOnlineOnlyEvent } from "../../lib/locationUtils";
 import { getDeduplicatedEvents } from "@/utils/eventDeduplication";
 
 export const useEventFiltering = (
@@ -67,7 +67,7 @@ export const useEventFiltering = (
       }
       
       // Filter out online events if excludeOnline is true
-      if (excludeOnline && isOnlineEvent(event)) {
+      if (excludeOnline && isOnlineOnlyEvent(event)) {
         console.log('Event filtered out - online event:', event.title);
         return false;
       }

--- a/supabase/functions/generate-ical/index.ts
+++ b/supabase/functions/generate-ical/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.171.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { categorizeEventByRegion, isOnlineEvent } from "../../../lib/locationUtils.ts";
+import { categorizeEventByRegion, isOnlineOnlyEvent } from "../../../lib/locationUtils.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -97,7 +97,7 @@ serve(async (req: Request) => {
       }
 
       // Apply online exclusion filter
-      if (excludeOnline && isOnlineEvent(event)) {
+      if (excludeOnline && isOnlineOnlyEvent(event)) {
         return false;
       }
       

--- a/supabase/functions/generate-rss/index.ts
+++ b/supabase/functions/generate-rss/index.ts
@@ -1,7 +1,7 @@
 
 import { serve } from "https://deno.land/std@0.171.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
-import { categorizeEventByRegion, isOnlineEvent } from "../../../lib/locationUtils.ts";
+import { categorizeEventByRegion, isOnlineOnlyEvent } from "../../../lib/locationUtils.ts";
 
 const corsHeaders = {
   "Access-Control-Allow-Origin": "*",
@@ -112,7 +112,7 @@ serve(async (req) => {
       }
 
       // Apply online exclusion filter
-      if (excludeOnline && isOnlineEvent(event)) {
+      if (excludeOnline && isOnlineOnlyEvent(event)) {
         console.log('Event filtered out due to online exclusion:', event.title);
         return false;
       }


### PR DESCRIPTION
## Summary

Hybrid Meetup events (with both IRL and online attendance options) were being stored as online-only and then filtered out when users checked "hide online events." This PR fixes the root cause in the scraper, closes a related false-positive in the frontend/backend online detection logic, and adds typed smoke tests to prevent regressions.

## What changed

**Scraper (`scrape_meetup.py`)**

- Hybrid events: the venue branch required `is_irl and not is_online`, so any event with both attend buttons fell through to the online branch. Changed to `if is_irl:` — physical venue is always captured when IRL attendance is available.
- Group events page URLs (e.g. `meetup.com/group/events/`): the trailing `/events/` was included in `group_path`, making the event card selector look for `.../events/events/123` which never matched. Now normalised to the group base URL before navigating.

**Online-only classification (`locationUtils.ts` + call sites)**

- Renamed `isOnlineEvent` → `isOnlineOnlyEvent` across all four call sites — the function identifies online-only events for exclusion, not hybrid ones.
- Added an early return before the description content check when `event.city` or `event.postal_code` is set — prevents a Google Meet link in a hybrid event's description from triggering a false online-only classification.

**Smoke tests**

Replaced the two single-URL weekly CI steps with a single typed URL step covering six URL categories: group, specific event, online-only event, hybrid event, in-person event, and group events page. Each category carries appropriate assertions — hybrid and in-person URLs assert every returned event has a `venue_address`, directly catching the scraper bug. All events are validated against the full 8-field schema with timezone-aware datetime checks.

URLs resolve from environment variables first, then `.env.local`, so the same test file works locally and in CI. A `.env.local.example` template is committed for onboarding.

## New optional CI secrets

| Secret | Purpose |
|---|---|
| `SMOKE_TEST_ONLINE_ONLY_EVENT_URL` | Online-only event assertion |
| `SMOKE_TEST_HYBRID_EVENT_URL` | Confirms hybrid → physical venue capture |
| `SMOKE_TEST_IN_PERSON_EVENT_URL` | In-person venue assertion |
| `SMOKE_TEST_GROUP_EVENTS_PAGE_URL` | Group events listing page |

Existing `SMOKE_TEST_GROUP_URL` and `SMOKE_TEST_EVENT_URL` secrets are reused — no secrets need to be removed or renamed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)