### PR TITLE
feat: Luma scraper rewrite, CI checks, and test fixes

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "Running unit tests..."
+npx vitest run --reporter=dot 2>&1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,61 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Run unit tests
+        run: npx vitest run
+
+      - name: Build
+        run: npm run build
+
+  smoke-tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: functions/scraping-events
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          cache-dependency-glob: "functions/scraping-events/uv.lock"
+
+      - name: Install Python 3.13
+        run: uv python install 3.13
+
+      - name: Install dependencies
+        run: uv sync --frozen
+
+      - name: Install Playwright browsers
+        run: uv run playwright install chromium --with-deps
+
+      - name: Run smoke tests
+        env:
+          DEBUG: "false"
+          GROUP_URL: ${{ secrets.SMOKE_TEST_GROUP_URL }}
+          EVENT_URL: ${{ secrets.SMOKE_TEST_EVENT_URL }}
+          ONLINE_ONLY_EVENT_URL: ${{ secrets.SMOKE_TEST_ONLINE_ONLY_EVENT_URL }}
+          HYBRID_EVENT_URL: ${{ secrets.SMOKE_TEST_HYBRID_EVENT_URL }}
+          IN_PERSON_EVENT_URL: ${{ secrets.SMOKE_TEST_IN_PERSON_EVENT_URL }}
+          GROUP_EVENTS_PAGE_URL: ${{ secrets.SMOKE_TEST_GROUP_EVENTS_PAGE_URL }}
+          LUMA_EVENT_URL: ${{ secrets.SMOKE_TEST_LUMA_EVENT_URL }}
+        run: uv run pytest tests/smoke/ -v --tb=short

--- a/.github/workflows/weekly-meetup-smoke-test.yml
+++ b/.github/workflows/weekly-meetup-smoke-test.yml
@@ -40,6 +40,7 @@ jobs:
           HYBRID_EVENT_URL: ${{ secrets.SMOKE_TEST_HYBRID_EVENT_URL }}
           IN_PERSON_EVENT_URL: ${{ secrets.SMOKE_TEST_IN_PERSON_EVENT_URL }}
           GROUP_EVENTS_PAGE_URL: ${{ secrets.SMOKE_TEST_GROUP_EVENTS_PAGE_URL }}
+          LUMA_EVENT_URL: ${{ secrets.SMOKE_TEST_LUMA_EVENT_URL }}
         run: uv run pytest tests/smoke/test_meetup_local_urls.py -v --tb=short
 
   claude-fix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,16 @@ SMOKE_TEST_URL=<meetup_group_url> claude -p "$(cat functions/scraping-events/scr
   --allowedTools "Bash,Read,Edit,Write" --max-turns 20
 ```
 
-CI: `.github/workflows/weekly-meetup-smoke-test.yml` runs smoke tests every Monday against both a group URL and a specific event URL; on failure it invokes the Claude fix agent and opens a PR. Requires `ANTHROPIC_API_KEY`, `SMOKE_TEST_GROUP_URL`, and `SMOKE_TEST_EVENT_URL` in repository secrets, and "Allow GitHub Actions to create and approve pull requests" enabled in Settings → Actions → General.
+CI: `.github/workflows/weekly-meetup-smoke-test.yml` runs smoke tests every Monday; on failure it invokes the Claude fix agent and opens a PR. Requires "Allow GitHub Actions to create and approve pull requests" enabled in Settings → Actions → General, plus these repository secrets:
+
+- `ANTHROPIC_API_KEY` — for the Claude fix agent
+- `SMOKE_TEST_GROUP_URL` — Meetup group page URL
+- `SMOKE_TEST_EVENT_URL` — specific Meetup event URL
+- `SMOKE_TEST_ONLINE_ONLY_EVENT_URL` — online-only event URL
+- `SMOKE_TEST_HYBRID_EVENT_URL` — hybrid (IRL + online) event URL
+- `SMOKE_TEST_IN_PERSON_EVENT_URL` — in-person event URL
+- `SMOKE_TEST_GROUP_EVENTS_PAGE_URL` — group events listing page URL
+- `SMOKE_TEST_LUMA_EVENT_URL` — Luma event URL (lu.ma or luma.com)
 
 ## Environment
 

--- a/functions/scraping-events/.env.local.example
+++ b/functions/scraping-events/.env.local.example
@@ -18,3 +18,6 @@ IN_PERSON_EVENT_URL=
 
 # The group's events listing page (e.g. meetup.com/group/events/)
 GROUP_EVENTS_PAGE_URL=
+
+# A Luma event page (lu.ma or luma.com short URL)
+LUMA_EVENT_URL=

--- a/functions/scraping-events/src/scraping_events/scrape_luma.py
+++ b/functions/scraping-events/src/scraping_events/scrape_luma.py
@@ -1,11 +1,10 @@
+import json
 import logging
 import re
 from datetime import datetime
 from urllib.parse import ParseResult as ParsedUrl
-from typing import Optional
 
-from playwright.async_api import Browser, TimeoutError as PlaywrightTimeoutError
-from playwright.async_api import expect as pw_expect
+from playwright.async_api import Browser
 
 from scraping_events.exceptions import ParsingError
 from scraping_events.playwright_utils import PageWrapper
@@ -15,188 +14,142 @@ LOGGER = logging.getLogger(__name__)
 
 
 def is_luma_url(url_parsed: ParsedUrl) -> bool:
-    """Check if URL is a Luma events URL."""
+    """Check if URL is a Luma events URL (lu.ma or luma.com)."""
     hostname = url_parsed.hostname
     if hostname is None:
         return False
-    return re.fullmatch(r".*\.?lu\.ma", hostname, flags=re.IGNORECASE) is not None
+    return re.fullmatch(r"(.*\.)?(lu\.ma|luma\.com)", hostname, flags=re.IGNORECASE) is not None
 
 
-async def _get_upcoming_event_urls(page_wrapper: PageWrapper, starting_url: str, max_events: int) -> list[str]:
-    """Get upcoming event URLs from a Luma organizer page."""
-    LOGGER.info(f"Looking for upcoming events on Luma page: {starting_url}")
-    await page_wrapper.navigate(starting_url)
-    page = page_wrapper.page
-    
-    # Wait for the page to load
-    try:
-        await page.wait_for_selector('[data-testid="event-card"]', timeout=10000)
-    except PlaywrightTimeoutError:
-        LOGGER.info(f"No events found on {starting_url}")
-        return []
-    
-    # Find all event cards
-    event_cards = page.locator('[data-testid="event-card"]')
-    event_count = await event_cards.count()
-    
-    LOGGER.info(f"Found {event_count} event cards on page")
-    
-    event_urls: list[str] = []
-    for i in range(min(event_count, max_events)):
-        try:
-            event_card = event_cards.nth(i)
-            # Get the event link
-            event_link = event_card.locator('a').first
-            event_url = await event_link.get_attribute('href')
-            
-            if event_url:
-                # Convert relative URLs to absolute
-                if event_url.startswith('/'):
-                    event_url = f"https://lu.ma{event_url}"
-                event_urls.append(event_url)
-                LOGGER.info(f"Found event URL: {event_url}")
-        except Exception as e:
-            LOGGER.warning(f"Error extracting URL from event card {i}: {e}")
-            continue
-    
-    LOGGER.info(f"Collected {len(event_urls)} event URLs")
-    return event_urls
-
-
-async def _get_event_details(page_wrapper: PageWrapper, event_url: str) -> Event:
-    """Extract event details from a Luma event page."""
-    LOGGER.info(f"Getting details for Luma event: {event_url}")
-    await page_wrapper.navigate(event_url)
-    page = page_wrapper.page
-    
-    # Wait for page to load
-    await page.wait_for_load_state('networkidle')
-    
-    try:
-        # Title
-        title_selector = 'h1[data-testid="event-title"]'
-        await page.wait_for_selector(title_selector, timeout=5000)
-        event_title = await page.locator(title_selector).inner_text()
-        event_title = event_title.strip()
-        
-        # Description
-        description = ""
-        try:
-            desc_selector = '[data-testid="event-description"]'
-            description = await page.locator(desc_selector).inner_text()
-            description = description.strip()
-        except Exception:
-            LOGGER.warning(f"Could not find description for event: {event_url}")
-        
-        # Date and time
-        event_time = None
-        try:
-            # Luma typically shows date/time in structured data or specific selectors
-            time_selector = '[data-testid="event-date-time"]'
-            time_text = await page.locator(time_selector).inner_text()
-            event_time = _parse_luma_datetime(time_text)
-        except Exception as e:
-            LOGGER.warning(f"Could not parse event time for {event_url}: {e}")
-            # Try alternative selectors
-            try:
-                # Look for datetime attributes or structured data
-                datetime_elem = page.locator('[datetime]').first
-                datetime_str = await datetime_elem.get_attribute('datetime')
-                if datetime_str:
-                    event_time = datetime.fromisoformat(datetime_str.replace('Z', '+00:00'))
-            except Exception:
-                LOGGER.error(f"Failed to extract event time from {event_url}")
-        
-        # Location/venue
-        venue_name = None
-        venue_address = None
-        venue_url = None
-        
-        try:
-            # Try to find location information
-            location_selector = '[data-testid="event-location"]'
-            location_text = await page.locator(location_selector).inner_text()
-            if location_text and location_text.strip():
-                # Check if it's an online event
-                if any(keyword in location_text.lower() for keyword in ['online', 'virtual', 'zoom', 'meet']):
-                    venue_name = location_text.strip()
-                else:
-                    venue_address = location_text.strip()
-                    # Try to extract venue name if available
-                    venue_name_elem = page.locator('[data-testid="venue-name"]')
-                    if await venue_name_elem.count() > 0:
-                        venue_name = await venue_name_elem.inner_text()
-        except Exception:
-            LOGGER.warning(f"Could not find location for event: {event_url}")
-        
-        # Image
-        image_url = None
-        try:
-            img_selector = '[data-testid="event-image"] img'
-            image_url = await page.locator(img_selector).get_attribute('src')
-        except Exception:
-            LOGGER.warning(f"Could not find image for event: {event_url}")
-        
-        return Event(
-            url=event_url,
-            title=event_title,
-            description=description,
-            time=event_time,
-            venue_name=venue_name,
-            venue_url=venue_url,
-            venue_address=venue_address,
-            image_url=image_url,
-        )
-        
-    except Exception as e:
-        LOGGER.error(f"Error extracting event details from {event_url}: {e}")
-        raise ParsingError(f"Failed to extract event details from {event_url}") from e
-
-
-def _parse_luma_datetime(time_text: str) -> Optional[datetime]:
-    """Parse Luma's datetime format."""
-    try:
-        # Luma might show dates like "Thu, Dec 12, 2024 at 6:00 PM MST"
-        # This is a simplified parser - might need refinement based on actual Luma format
-        
-        # Remove common words and normalize
-        cleaned = re.sub(r'\s+at\s+', ' ', time_text)
-        cleaned = re.sub(r'\s+', ' ', cleaned).strip()
-        
-        # Try different parsing patterns
-        patterns = [
-            r'(\w{3}),?\s+(\w{3})\s+(\d{1,2}),?\s+(\d{4})\s+(\d{1,2}):(\d{2})\s*([AP]M)',
-            r'(\w{3})\s+(\d{1,2}),?\s+(\d{4})\s+(\d{1,2}):(\d{2})\s*([AP]M)',
-            r'(\d{1,2})/(\d{1,2})/(\d{4})\s+(\d{1,2}):(\d{2})\s*([AP]M)',
-        ]
-        
-        for pattern in patterns:
-            match = re.search(pattern, cleaned, re.IGNORECASE)
-            if match:
-                # This would need proper date parsing logic
-                # For now, return None to avoid errors
-                LOGGER.warning(f"Date parsing not fully implemented for: {time_text}")
-                return None
-        
+def _extract_json_ld(page_source: str | None) -> dict | None:
+    """Parse a JSON-LD object from a script tag's text content."""
+    if not page_source:
         return None
-        
-    except Exception as e:
-        LOGGER.error(f"Error parsing Luma datetime '{time_text}': {e}")
-        return None
+    try:
+        data = json.loads(page_source)
+        if isinstance(data, dict):
+            return data
+    except (json.JSONDecodeError, TypeError):
+        pass
+    return None
+
+
+def _event_from_json_ld(json_ld: dict, event_url: str) -> Event:
+    """Build an Event from a schema.org JSON-LD Event object."""
+    title = json_ld.get("name", "").strip()
+    if not title:
+        raise ParsingError(f"No event name in JSON-LD for {event_url}")
+
+    description = json_ld.get("description", "").strip()
+
+    start_date = json_ld.get("startDate")
+    if not start_date:
+        raise ParsingError(f"No startDate in JSON-LD for {event_url}")
+    try:
+        event_time = datetime.fromisoformat(start_date)
+    except ValueError as e:
+        raise ParsingError(f"Invalid startDate '{start_date}' in JSON-LD for {event_url}") from e
+
+    # Location
+    venue_name = None
+    venue_address = None
+    venue_url = None
+    location = json_ld.get("location")
+    if isinstance(location, dict):
+        venue_name = location.get("name")
+        venue_url = location.get("url")
+        address = location.get("address")
+        if isinstance(address, dict):
+            parts = [
+                address.get("streetAddress"),
+                address.get("addressLocality"),
+                address.get("addressRegion"),
+            ]
+            venue_address = ", ".join(p for p in parts if p) or None
+        elif isinstance(address, str):
+            venue_address = address or None
+
+    # Image
+    image_url = None
+    images = json_ld.get("image")
+    if isinstance(images, list) and images:
+        image_url = images[0]
+    elif isinstance(images, str):
+        image_url = images
+
+    # Canonical URL — prefer the @id from JSON-LD (luma.com form)
+    canonical_url = json_ld.get("@id") or event_url
+
+    return Event(
+        url=canonical_url,
+        title=title,
+        description=description,
+        time=event_time,
+        venue_name=venue_name,
+        venue_url=venue_url,
+        venue_address=venue_address,
+        image_url=image_url,
+    )
+
+
+async def _get_json_ld(page_wrapper: PageWrapper, url: str) -> dict | None:
+    """Navigate to a URL and return the first JSON-LD object, or None."""
+    await page_wrapper.navigate(url)
+    page = page_wrapper.page
+    await page.wait_for_load_state("domcontentloaded")
+
+    json_ld_texts: list[str] = await page.evaluate("""() => {
+        const scripts = document.querySelectorAll('script[type="application/ld+json"]');
+        return Array.from(scripts).map(s => s.textContent);
+    }""")
+
+    for text in json_ld_texts:
+        result = _extract_json_ld(text)
+        if result:
+            return result
+    return None
 
 
 async def scrape_luma(browser: Browser, url: str, max_events: int) -> list[Event]:
-    """Scrape events from a Luma organizer page."""
+    """Scrape events from a Luma URL (single event or organizer/calendar page).
+
+    Routing is based on JSON-LD @type:
+    - @type=Event: scrape that single event directly
+    - @type=Organization: extract event URLs from the nested events[] array
+    """
     async with PageWrapper.open(browser) as page_wrapper:
-        event_urls = await _get_upcoming_event_urls(page_wrapper, url, max_events)
-        events: list[Event] = []
-        
-        for event_url in event_urls:
-            try:
-                event = await _get_event_details(page_wrapper, event_url)
-                events.append(event)
-            except Exception as e:
-                LOGGER.error(f"Failed to scrape event {event_url}: {e}")
-                continue
-        
-        return events
+        json_ld = await _get_json_ld(page_wrapper, url)
+        if json_ld is None:
+            raise ParsingError(f"No JSON-LD found on {url}")
+
+        ld_type = json_ld.get("@type")
+
+        if ld_type == "Event":
+            LOGGER.info(f"Single event page: {url}")
+            return [_event_from_json_ld(json_ld, url)]
+
+        if ld_type == "Organization":
+            LOGGER.info(f"Organization page: {url}")
+            nested_events = json_ld.get("events", [])
+            if not isinstance(nested_events, list):
+                return []
+
+            events: list[Event] = []
+            for event_ld in nested_events[:max_events]:
+                if not isinstance(event_ld, dict) or event_ld.get("@type") != "Event":
+                    continue
+                event_url = event_ld.get("@id") or url
+                try:
+                    # The nested JSON-LD may be partial — navigate to the full event page
+                    full_ld = await _get_json_ld(page_wrapper, event_url)
+                    if full_ld and full_ld.get("@type") == "Event":
+                        events.append(_event_from_json_ld(full_ld, event_url))
+                    else:
+                        # Fall back to the partial nested data
+                        events.append(_event_from_json_ld(event_ld, event_url))
+                except (ParsingError, Exception) as e:
+                    LOGGER.error(f"Failed to scrape event {event_url}: {e}")
+                    continue
+            return events
+
+        raise ParsingError(f"Unexpected JSON-LD @type '{ld_type}' on {url}")

--- a/functions/scraping-events/tests/smoke/test_meetup_local_urls.py
+++ b/functions/scraping-events/tests/smoke/test_meetup_local_urls.py
@@ -42,6 +42,7 @@ _URL_VARS: list[tuple[str, str | None, int]] = [
     ("HYBRID_EVENT_URL", "physical", 1),
     ("IN_PERSON_EVENT_URL", "physical", 1),
     ("GROUP_EVENTS_PAGE_URL", None, 0),
+    ("LUMA_EVENT_URL", None, 1),
 ]
 
 

--- a/src/components/AddEventModal.tsx
+++ b/src/components/AddEventModal.tsx
@@ -68,8 +68,8 @@ export default function AddEventModal({ open, onOpenChange }: { open: boolean, o
       const match = link.match(/meetup\.com\/([^\/]+)/);
       return match ? `meetup-${match[1]}` : null;
     }
-    if (link.includes("luma.com")) {
-      const match = link.match(/luma\.com\/([^\/]+)/);
+    if (link.includes("luma.com") || link.includes("lu.ma")) {
+      const match = link.match(/(?:luma\.com|lu\.ma)\/([^\/]+)/);
       return match ? `luma-${match[1]}` : null;
     }
     return null;

--- a/src/components/EventStats.tsx
+++ b/src/components/EventStats.tsx
@@ -31,7 +31,7 @@ export const EventStats = ({ events, groups, filteredCount, hasActiveFilters = f
     const url = event.link?.toLowerCase() || '';
     if (url.includes('meetup.com')) {
       sourceStats.meetup++;
-    } else if (url.includes('lu.ma')) {
+    } else if (url.includes('lu.ma') || url.includes('luma.com')) {
       sourceStats.luma++;
     } else if (url.includes('eventbrite.com')) {
       sourceStats.eventbrite++;

--- a/tests/locationUtils.events.test.ts
+++ b/tests/locationUtils.events.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeAll } from 'vitest';
 import fs from 'fs/promises';
 import path from 'path';
-import { isOnlineEvent, categorizeEventByRegion } from '../lib/locationUtils';
+import { isOnlineOnlyEvent, categorizeEventByRegion } from '../lib/locationUtils';
 
 let events: any[] = [];
 
@@ -14,13 +14,13 @@ describe('locationUtils tests using real events from events.fixture.json', () =>
   it('classifies events with explicit "Online event" venue as online', () => {
     const e = events.find(ev => ev.venue_name && String(ev.venue_name).toLowerCase().includes('online'));
     expect(e).toBeTruthy();
-    if (e) expect(isOnlineEvent(e)).toBe(true);
+    if (e) expect(isOnlineOnlyEvent(e)).toBe(true);
   });
 
   it('does not classify clearly physical events as online (address in location)', () => {
     const e = events.find(ev => ev.location && /\d/.test(String(ev.location)));
     expect(e).toBeTruthy();
-    if (e) expect(isOnlineEvent(e)).toBe(false);
+    if (e) expect(isOnlineOnlyEvent(e)).toBe(false);
   });
 
   it('does not classify hybrid events (venue + online link in description) as online when venue contains physical address', () => {
@@ -34,7 +34,7 @@ describe('locationUtils tests using real events from events.fixture.json', () =>
     expect(e).toBeTruthy();
     if (e) {
       // because the venue contains a physical address we expect our heuristics to prefer in-person
-      expect(isOnlineEvent(e)).toBe(false);
+      expect(isOnlineOnlyEvent(e)).toBe(false);
     }
   });
 

--- a/tests/locationUtils.test.ts
+++ b/tests/locationUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { categorizeEventByRegion, isOnlineEvent, UTAH_REGIONS } from '../lib/locationUtils';
+import { categorizeEventByRegion, isOnlineOnlyEvent, UTAH_REGIONS } from '../lib/locationUtils';
 
 describe('locationUtils shared tests', () => {
   it('categorizes Salt Lake County city', () => {
@@ -19,27 +19,27 @@ describe('locationUtils shared tests', () => {
 
   it('detects online via title/description', () => {
     const event = { title: 'Weekly Zoom Meeting', description: 'Join via Zoom' };
-    expect(isOnlineEvent(event)).toBe(true);
+    expect(isOnlineOnlyEvent(event)).toBe(true);
   });
 
   it('does not classify meetup in title as online when venue is unspecified', () => {
     const event = { title: 'Monthly Meetup: Project Night', description: 'An in-person social' };
-    expect(isOnlineEvent(event)).toBe(false);
+    expect(isOnlineOnlyEvent(event)).toBe(false);
   });
 
   it('classifies online when venue explicitly mentions Zoom', () => {
     const event = { title: 'Monthly Meetup: Project Night', venue_name: 'Zoom', description: 'Online meeting' };
-    expect(isOnlineEvent(event)).toBe(true);
+    expect(isOnlineOnlyEvent(event)).toBe(true);
   });
 
   it('classifies online when description contains a meeting URL', () => {
     const event = { title: 'Community Chat', description: 'Join at https://zoom.us/j/123456789' };
-    expect(isOnlineEvent(event)).toBe(true);
+    expect(isOnlineOnlyEvent(event)).toBe(true);
   });
 
   it('does not detect online for physical address', () => {
     const event = { title: 'Hack Night', location: 'Salt Lake City Library', description: 'In-person' };
-    expect(isOnlineEvent(event)).toBe(false);
+    expect(isOnlineOnlyEvent(event)).toBe(false);
   });
 
   it('exports UTAH_REGIONS array', () => {


### PR DESCRIPTION
## Summary

- **Rewrite Luma scraper** (`scrape_luma.py`): Replaced fragile DOM selectors with JSON-LD structured data extraction. URL routing is now driven by `@type` in JSON-LD (`Event` for single events, `Organization` for calendar pages with nested events). Supports both `lu.ma` and `luma.com` domains. Fixed regex to not over-match (e.g. `evilu.ma`).
- **Frontend domain consistency**: Updated `EventStats.tsx` and `AddEventModal.tsx` to recognize both `lu.ma` and `luma.com` domains, matching the scraper's canonicalization.
- **Fix broken unit tests**: Updated `locationUtils.test.ts` and `locationUtils.events.test.ts` to use renamed `isOnlineOnlyEvent` function (broken since de8565a).
- **Add Luma smoke test**: New `LUMA_EVENT_URL` entry in smoke test URL vars, CI workflow, and `.env.local.example`.
- **Add CI workflow** (`.github/workflows/ci.yml`): Runs on all PRs and pushes to main with two jobs: `unit-tests` (vitest + build) and `smoke-tests` (all provider URLs from secrets).
- **Add pre-commit hook** (`.githooks/pre-commit`): Runs vitest unit tests before each commit. Developers opt in with `git config core.hooksPath .githooks`.

## New CI secret

| Secret | Purpose |
|---|---|
| `SMOKE_TEST_LUMA_EVENT_URL` | Luma event URL for smoke test |

## Post-merge setup

To enforce CI checks as merge requirements:

1. Go to **Settings → Branches → Add branch protection rule**
2. Set branch name pattern to `main`
3. Enable **Require status checks to pass before merging**
4. Add `unit-tests` and `smoke-tests` as required checks
5. Add `SMOKE_TEST_LUMA_EVENT_URL` to repository secrets

To enable the pre-commit hook locally:
```bash
git config core.hooksPath .githooks
```

## Test plan

- [x] All 13 vitest unit tests pass (including isOnlineOnlyEvent rename fix)
- [x] Production build succeeds
- [x] Luma single-event URL smoke test passes (`luma.com/9n3u77dm`)
- [x] Luma organization page scraping works (`luma.com/ai-driven-development-utah`)
- [x] `lu.ma` domain routing works
- [x] All 8 smoke tests pass (6 Meetup + 1 Luma + 1 legacy)
- [x] Pre-commit hook runs tests and blocks on failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)