### PR TITLE
fix: hybrid events no longer hidden by online filter

### DIFF
--- a/lib/locationUtils.ts
+++ b/lib/locationUtils.ts
@@ -111,6 +111,11 @@ export function isOnlineOnlyEvent(event: Record<string, any>): boolean {
     // Presence of a physical address or city name in venueText should strongly indicate in-person
     const hasPhysical = /\d{1,5}\s+\w+/.test(venueText) || /\b(street|st\.|avenue|ave\.|road|rd\.|lane|ln\.|drive|dr\.)\b/i.test(venueText);
     if (hasPhysical) return false;
+
+    // A venue_name that didn't match any online/platform indicators above is a real
+    // physical venue (e.g. "Weave", "The Salt Mine"). Treat it as in-person even if
+    // the description contains a meeting link (hybrid event).
+    if (event.venue_name) return false;
   }
 
   // A populated city or postal_code is an unambiguous physical presence signal —

--- a/tests/locationUtils.test.ts
+++ b/tests/locationUtils.test.ts
@@ -42,6 +42,15 @@ describe('locationUtils shared tests', () => {
     expect(isOnlineOnlyEvent(event)).toBe(false);
   });
 
+  it('does not classify hybrid event as online when venue_name is a physical place', () => {
+    const event = {
+      title: 'Go Figure: A Tour of the math Package',
+      venue_name: 'Weave',
+      description: 'Video call link: https://meet.google.com/dkn-ekxb-qrj Or dial: (US) +1 336-673-3641'
+    };
+    expect(isOnlineOnlyEvent(event)).toBe(false);
+  });
+
   it('exports UTAH_REGIONS array', () => {
     expect(Array.isArray(UTAH_REGIONS)).toBe(true);
     expect(UTAH_REGIONS.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- **Bug**: "Hide online events" toggle was hiding hybrid events (e.g. Utah Go User Group at "Weave") because their descriptions contain video call links
- **Fix**: A `venue_name` that doesn't match any online/platform indicators is now treated as evidence of a physical venue, so hybrid events with meeting links in the description stay visible
- **Test**: Added regression test for hybrid event with physical venue name + Google Meet link in description

## Root cause
`isOnlineOnlyEvent` only recognized physical venues by street address patterns or explicit `city`/`postal_code` fields. A venue like "Weave" with no street number fell through to the description check, where a Google Meet URL caused it to be classified as online-only.

## Test plan
- [x] All 14 unit tests pass (including new hybrid event test)
- [ ] Verify on production that the Utah Go User Group event at "Weave" is no longer hidden when "Hide online events" is toggled

🤖 Generated with [Claude Code](https://claude.com/claude-code)