### PR TITLE
feat: add per-event "Add to calendar" menu on event cards

### DIFF
--- a/src/components/EventsTimeline.tsx
+++ b/src/components/EventsTimeline.tsx
@@ -2,13 +2,22 @@
 import React from "react";
 import { format, parseISO, isSameDay, isToday, isTomorrow, isYesterday, isPast, formatDistanceToNow } from "date-fns";
 import { Badge } from "@/components/ui/badge";
-import { MapPin, Clock, ExternalLink } from "lucide-react";
+import { MapPin, Clock, ExternalLink, MoreVertical, Calendar, Download } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { buildGoogleCalendarUrl } from "@/utils/calendarLinks";
+import { buildEventIcalUrl } from "@/utils/eventUrls";
 
 interface Event {
   id: string;
   title: string;
   event_date: string;
   start_time?: string;
+  end_time?: string;
   location?: string;
   venue_name?: string;
   address_line_1?: string;
@@ -109,6 +118,61 @@ const getEventTags = (event: Event) => {
   // Return group tags if event has no tags
   return event.groups?.tags || [];
 };
+
+function downloadIcsFor(eventId: string) {
+  const a = document.createElement("a");
+  a.href = buildEventIcalUrl(eventId);
+  a.download = `${eventId}.ics`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+}
+
+function AddToCalendarMenu({ event }: { event: Event }) {
+  return (
+    <div className="absolute top-3 right-3">
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          aria-label={`Add "${event.title}" to calendar`}
+          onClick={(e) => e.stopPropagation()}
+          className="flex h-11 w-11 items-center justify-center rounded-md bg-white/5 text-white/70 border border-white/10 hover:bg-white/15 hover:text-white hover:border-white/20 data-[state=open]:bg-white/15 data-[state=open]:text-white data-[state=open]:border-white/20 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/60"
+        >
+          <MoreVertical className="w-4 h-4" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" collisionPadding={8}>
+          <DropdownMenuItem asChild>
+            <a
+              href={buildGoogleCalendarUrl(event)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Calendar className="w-4 h-4 mr-2" />
+              Add to Google Calendar
+            </a>
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              downloadIcsFor(event.id);
+            }}
+          >
+            <Download className="w-4 h-4 mr-2" />
+            Add to Apple Calendar
+          </DropdownMenuItem>
+          <DropdownMenuItem
+            onSelect={(e) => {
+              e.preventDefault();
+              downloadIcsFor(event.id);
+            }}
+          >
+            <Download className="w-4 h-4 mr-2" />
+            Download .ics
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
 
 export function EventsTimeline({ events, isLoading, error, visibleCount, onShowMore }: EventsTimelineProps) {
   if (isLoading) {
@@ -212,11 +276,13 @@ export function EventsTimeline({ events, isLoading, error, visibleCount, onShowM
               return (
                 <div
                   key={event.id}
-                  className="bg-gradient-to-br from-[#22243A]/80 via-[#23283B]/80 to-[#383B53]/80 backdrop-blur-sm border border-white/10 rounded-xl p-6 hover:border-primary/30 transition-all duration-200"
+                  className="relative bg-gradient-to-br from-[#22243A]/80 via-[#23283B]/80 to-[#383B53]/80 backdrop-blur-sm border border-white/10 rounded-xl p-6 hover:border-primary/30 transition-all duration-200"
                 >
+                  <AddToCalendarMenu event={event} />
+
                   {/* Time and duration */}
                   {timeDisplay && (
-                    <div className="flex items-center gap-2 text-sm text-primary mb-3">
+                    <div className="flex items-center gap-2 text-sm text-primary mb-3 pr-12">
                       <Clock className="w-4 h-4" />
                       <span className="font-medium">{timeDisplay}</span>
                     </div>
@@ -224,13 +290,13 @@ export function EventsTimeline({ events, isLoading, error, visibleCount, onShowM
 
                   {/* Group name */}
                   {event.groups?.name && (
-                    <div className="text-sm text-muted-foreground mb-1">
+                    <div className="text-sm text-muted-foreground mb-1 pr-12">
                       {event.groups.name}
                     </div>
                   )}
 
                   {/* Event title */}
-                  <h3 className="text-xl font-semibold text-white mb-2">
+                  <h3 className="text-xl font-semibold text-white mb-2 pr-12">
                     {event.link ? (
                       <a
                         href={event.link}

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -17,6 +17,7 @@ async function fetchUpcomingEvents() {
       title,
       event_date,
       start_time,
+      end_time,
       location,
       venue_name,
       address_line_1,

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -4,6 +4,7 @@ export interface Event {
   title: string;
   event_date: string;
   start_time?: string;
+  end_time?: string;
   location?: string;
   venue_name?: string;
   address_line_1?: string;

--- a/src/utils/calendarLinks.ts
+++ b/src/utils/calendarLinks.ts
@@ -1,0 +1,123 @@
+import { formatICalDate } from "../../lib/feedUtils";
+import { isOnlineOnlyEvent } from "../../lib/locationUtils";
+
+export interface CalendarEvent {
+  id: string;
+  title: string;
+  event_date: string;
+  start_time?: string;
+  end_time?: string;
+  location?: string;
+  venue_name?: string;
+  address_line_1?: string;
+  address_line_2?: string;
+  city?: string;
+  state_province?: string;
+  postal_code?: string;
+  country?: string;
+  link?: string;
+  description?: string;
+}
+
+export function validateHttpUrl(url: string | null | undefined): string {
+  if (!url) return "";
+  return /^https?:\/\//i.test(url) ? url : "";
+}
+
+export function buildFullAddress(event: CalendarEvent): string {
+  return [
+    event.address_line_1,
+    event.address_line_2,
+    event.city,
+    event.state_province,
+    event.postal_code,
+    event.country,
+  ]
+    .filter(Boolean)
+    .join(", ");
+}
+
+export function getCalendarLocation(event: CalendarEvent): string {
+  if (isOnlineOnlyEvent(event)) {
+    return validateHttpUrl(event.link);
+  }
+  const address = buildFullAddress(event);
+  if (address) return address;
+  return event.venue_name || event.location || "";
+}
+
+export function getEventEndTime(startTime: string | undefined, endTime: string | undefined): string | undefined {
+  if (endTime) return endTime.slice(0, 5);
+  if (!startTime) return undefined;
+  const [hStr, mStr] = startTime.slice(0, 5).split(":");
+  const hours = Number(hStr);
+  const minutes = Number(mStr);
+  if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return undefined;
+  const nextHour = (hours + 1) % 24;
+  return `${String(nextHour).padStart(2, "0")}:${String(minutes).padStart(2, "0")}`;
+}
+
+function formatGoogleDate(dateYmd: string): string {
+  return dateYmd.replace(/-/g, "");
+}
+
+function addOneDay(dateYmd: string): string {
+  const [y, m, d] = dateYmd.split("-").map(Number);
+  const dt = new Date(Date.UTC(y, m - 1, d));
+  dt.setUTCDate(dt.getUTCDate() + 1);
+  const yy = dt.getUTCFullYear();
+  const mm = String(dt.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(dt.getUTCDate()).padStart(2, "0");
+  return `${yy}${mm}${dd}`;
+}
+
+type GoogleCalPayload =
+  | { kind: "timed"; start: string; end: string; tz: "America/Denver" }
+  | { kind: "allDay"; start: string; end: string };
+
+export function toGooglePayload(event: CalendarEvent): GoogleCalPayload {
+  if (!event.start_time) {
+    const start = formatGoogleDate(event.event_date);
+    const end = addOneDay(event.event_date);
+    return { kind: "allDay", start, end };
+  }
+
+  const start = formatICalDate(event.event_date, event.start_time);
+  const end = formatICalDate(event.event_date, getEventEndTime(event.start_time, event.end_time));
+  return { kind: "timed", start, end, tz: "America/Denver" };
+}
+
+export function buildGoogleCalendarUrl(event: CalendarEvent): string {
+  const payload = toGooglePayload(event);
+  const params = new URLSearchParams();
+  params.set("action", "TEMPLATE");
+  params.set("text", event.title);
+
+  const datesValue =
+    payload.kind === "timed"
+      ? `${payload.start}/${payload.end}`
+      : `${payload.start}/${payload.end}`;
+  params.set("dates", datesValue);
+
+  if (payload.kind === "timed") {
+    params.set("ctz", payload.tz);
+  }
+
+  const location = getCalendarLocation(event);
+  if (location) params.set("location", location);
+
+  const sourceUrl = validateHttpUrl(event.link);
+  const detailParts: string[] = [];
+  if (sourceUrl) detailParts.push(sourceUrl);
+  if (event.description) detailParts.push(event.description.slice(0, 1500));
+  if (detailParts.length > 0) {
+    params.set("details", detailParts.join("\n\n"));
+  }
+
+  // URLSearchParams encodes `/` as `%2F`; Google accepts both in `dates`, but the
+  // raw `/` is canonical. Restore it so the URL matches documented examples.
+  return `https://calendar.google.com/calendar/render?${params.toString().replace(
+    /dates=([^&]+)/,
+    (_, v: string) => `dates=${v.replace(/%2F/g, "/")}`
+  )}`;
+}

--- a/src/utils/eventUrls.ts
+++ b/src/utils/eventUrls.ts
@@ -1,6 +1,12 @@
 
 import { UtahRegion } from "@/types/events";
 
+const SUPABASE_FUNCTIONS_BASE = "https://gocvjqljtcxtcrwvfwez.supabase.co/functions/v1";
+
+export const buildEventIcalUrl = (eventId: string) => {
+  return `${SUPABASE_FUNCTIONS_BASE}/generate-ical?event=${encodeURIComponent(eventId)}`;
+};
+
 export const generateICalUrl = (selectedGroups: string[], selectedTags: string[], selectedRegions: UtahRegion[], excludeOnline: boolean) => {
   const params = new URLSearchParams();
   if (selectedGroups.length > 0) {

--- a/supabase/functions/generate-ical/index.ts
+++ b/supabase/functions/generate-ical/index.ts
@@ -9,6 +9,9 @@ const corsHeaders = {
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
 };
 
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
 // Helper function to escape iCal text
 function escapeICalText(text: string): string {
   return text
@@ -19,6 +22,67 @@ function escapeICalText(text: string): string {
     .replace(/\r/g, '');
 }
 
+function validateHttpUrl(url: string | null | undefined): string {
+  if (!url) return "";
+  return /^https?:\/\//i.test(url) ? url : "";
+}
+
+// Render a single VEVENT block. Kept identical to the bulk branch's rendering so
+// subscribers see the same output for an event regardless of which endpoint
+// produced it.
+function renderVEvent(event: any): string {
+  const startDate = formatICalDate(event.event_date, event.start_time);
+  const endDate = event.end_time
+    ? formatICalDate(event.event_date, event.end_time)
+    : formatICalDate(event.event_date, event.start_time ? `${parseInt(event.start_time.split(':')[0]) + 1}:${event.start_time.split(':')[1]}` : '23:59');
+
+  const groupName = event.groups?.name || 'Unlisted Group';
+  const description = event.description ? escapeICalText(event.description) : '';
+  const location = event.location ? escapeICalText(event.location).replace(/https?:\/\/[^\s]+/g, '') : '';
+  const prefixedTitle = escapeICalText(`${groupName}: ${event.title}`);
+
+  return `BEGIN:VEVENT
+UID:${event.id}@utahdevevents.com
+DTSTART;TZID=us-mountain:${startDate}
+DTEND;TZID=us-mountain:${endDate}
+SUMMARY:${prefixedTitle}
+DESCRIPTION:${description}\\n\\nGroup: ${groupName}${event.tags ? `\\n\\nTags: ${event.tags.join(', ')}` : ''}
+LOCATION:${location}
+STATUS:CONFIRMED
+SEQUENCE:0
+END:VEVENT`;
+}
+
+function wrapVCalendar(vevents: string): string {
+  return `BEGIN:VCALENDAR
+VERSION:2.0
+PRODID:-//Utah Dev Events//Utah Dev Events Calendar//EN
+CALSCALE:GREGORIAN
+METHOD:PUBLISH
+X-WR-CALNAME:Utah Dev Events
+X-WR-CALDESC:Utah Developer Community Events
+X-WR-TIMEZONE:us-mountain
+BEGIN:VTIMEZONE
+TZID:us-mountain
+BEGIN:DAYLIGHT
+TZOFFSETFROM:-0700
+TZOFFSETTO:-0600
+TZNAME:MDT
+DTSTART:20070311T020000
+RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
+END:DAYLIGHT
+BEGIN:STANDARD
+TZOFFSETFROM:-0600
+TZOFFSETTO:-0700
+TZNAME:MST
+DTSTART:20071104T020000
+RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
+END:STANDARD
+END:VTIMEZONE
+${vevents}
+END:VCALENDAR`;
+}
+
 serve(async (req: Request) => {
   // Handle CORS preflight requests
   if (req.method === "OPTIONS") {
@@ -27,13 +91,81 @@ serve(async (req: Request) => {
 
   try {
     const url = new URL(req.url);
+    const eventId = url.searchParams.get("event");
+
+    // Single-event branch: return a per-event .ics. Used by "Add to Apple
+    // Calendar" / "Download .ics" menu items on each event card. Requires a
+    // real HTTPS endpoint (not blob/data URI) so iOS Safari can hand the file
+    // to Calendar.app.
+    if (eventId !== null) {
+      if (eventId.length > 36 || !UUID_RE.test(eventId)) {
+        return new Response("Bad Request", { status: 400, headers: corsHeaders });
+      }
+
+      const supabase = createClient(
+        SUPABASE_URL,
+        Deno.env.get("SUPABASE_ANON_KEY") || ""
+      );
+
+      const { data: event, error } = await supabase
+        .from("events")
+        .select(`
+          id,
+          title,
+          event_date,
+          start_time,
+          end_time,
+          location,
+          venue_name,
+          city,
+          address_line_1,
+          address_line_2,
+          description,
+          tags,
+          link,
+          group_id,
+          groups (
+            name,
+            status,
+            tags
+          )
+        `)
+        .eq("id", eventId)
+        .eq("status", "approved")
+        .maybeSingle();
+
+      if (error || !event) {
+        return new Response("Not Found", { status: 404, headers: corsHeaders });
+      }
+
+      // Parity with bulk path: reject unapproved groups (only null group is acceptable)
+      if (event.groups && event.groups.status !== "approved") {
+        return new Response("Not Found", { status: 404, headers: corsHeaders });
+      }
+
+      // Strip unsafe link URLs before they land in any calendar field
+      const safeEvent = { ...event, link: validateHttpUrl(event.link) };
+
+      const ics = wrapVCalendar(renderVEvent(safeEvent));
+
+      return new Response(ics, {
+        status: 200,
+        headers: {
+          ...corsHeaders,
+          "Content-Type": "text/calendar; charset=utf-8",
+          "Content-Disposition": `attachment; filename="${event.id}.ics"`,
+          "Cache-Control": "public, max-age=3600, s-maxage=86400",
+        },
+      });
+    }
+
     const selectedGroups = url.searchParams.get('groups')?.split(',').filter(Boolean) || [];
     const selectedTags = url.searchParams.get('tags')?.split(',').filter(Boolean) || [];
     const selectedRegions = url.searchParams.get('regions')?.split(',').filter(Boolean) || [];
     const excludeOnline = url.searchParams.get('excludeOnline') === 'true';
 
     const supabase = createClient(
-      "https://gocvjqljtcxtcrwvfwez.supabase.co",
+      SUPABASE_URL,
       Deno.env.get('SUPABASE_ANON_KEY') || ""
     );
 
@@ -95,80 +227,32 @@ serve(async (req: Request) => {
       if (excludeOnline && isOnlineOnlyEvent(event)) {
         return false;
       }
-      
+
       // If no group/tag filters are selected, show all events (after region/online filtering)
       if (selectedGroups.length === 0 && selectedTags.length === 0) {
         return true;
       }
-      
+
       // Check if event matches any selected group
-      const matchesGroup = selectedGroups.length === 0 || 
+      const matchesGroup = selectedGroups.length === 0 ||
         (event.group_id && selectedGroups.includes(event.group_id));
-      
+
       // Check if event matches any selected tag
       // Use event tags if available, otherwise fall back to group tags
-      const eventTagsToCheck = event.tags && event.tags.length > 0 
-        ? event.tags 
+      const eventTagsToCheck = event.tags && event.tags.length > 0
+        ? event.tags
         : (event.groups?.tags || []);
-      
-      const matchesTag = selectedTags.length === 0 || 
+
+      const matchesTag = selectedTags.length === 0 ||
         eventTagsToCheck.some((tag: string) => selectedTags.includes(tag));
-      
+
       // Return true if event matches ANY of the selected groups OR ANY of the selected tags
       return matchesGroup || matchesTag;
     }) || [];
 
     // Generate iCal content
-    const icalEvents = filteredEvents.map((event: any) => {
-      const startDate = formatICalDate(event.event_date, event.start_time);
-      const endDate = event.end_time 
-        ? formatICalDate(event.event_date, event.end_time)
-        : formatICalDate(event.event_date, event.start_time ? `${parseInt(event.start_time.split(':')[0]) + 1}:${event.start_time.split(':')[1]}` : '23:59');
-      
-      const groupName = event.groups?.name || 'Unlisted Group';
-      const description = event.description ? escapeICalText(event.description) : '';
-      const location = event.location ? escapeICalText(event.location).replace(/https?:\/\/[^\s]+/g, '') : '';
-      const prefixedTitle = escapeICalText(`${groupName}: ${event.title}`);
-
-      return `BEGIN:VEVENT
-UID:${event.id}@utahdevevents.com
-DTSTART;TZID=us-mountain:${startDate}
-DTEND;TZID=us-mountain:${endDate}
-SUMMARY:${prefixedTitle}
-DESCRIPTION:${description}\\n\\nGroup: ${groupName}${event.tags ? `\\n\\nTags: ${event.tags.join(', ')}` : ''}
-LOCATION:${location}
-STATUS:CONFIRMED
-SEQUENCE:0
-END:VEVENT`;
-    }).join('\n');
-
-    const icalContent = `BEGIN:VCALENDAR
-VERSION:2.0
-PRODID:-//Utah Dev Events//Utah Dev Events Calendar//EN
-CALSCALE:GREGORIAN
-METHOD:PUBLISH
-X-WR-CALNAME:Utah Dev Events
-X-WR-CALDESC:Utah Developer Community Events
-X-WR-TIMEZONE:us-mountain
-BEGIN:VTIMEZONE
-TZID:us-mountain
-BEGIN:DAYLIGHT
-TZOFFSETFROM:-0700
-TZOFFSETTO:-0600
-TZNAME:MDT
-DTSTART:20070311T020000
-RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=2SU
-END:DAYLIGHT
-BEGIN:STANDARD
-TZOFFSETFROM:-0600
-TZOFFSETTO:-0700
-TZNAME:MST
-DTSTART:20071104T020000
-RRULE:FREQ=YEARLY;BYMONTH=11;BYDAY=1SU
-END:STANDARD
-END:VTIMEZONE
-${icalEvents}
-END:VCALENDAR`;
+    const icalEvents = filteredEvents.map(renderVEvent).join('\n');
+    const icalContent = wrapVCalendar(icalEvents);
 
     return new Response(icalContent, {
       status: 200,
@@ -182,8 +266,8 @@ END:VCALENDAR`;
     console.error("Error generating iCal:", err);
     return new Response(
       JSON.stringify({ message: "Failed to generate iCal", error: err.message }),
-      { 
-        status: 500, 
+      {
+        status: 500,
         headers: { ...corsHeaders, "Content-Type": "application/json" }
       }
     );

--- a/tests/calendarLinks.test.ts
+++ b/tests/calendarLinks.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildGoogleCalendarUrl,
+  getCalendarLocation,
+  getEventEndTime,
+  toGooglePayload,
+  validateHttpUrl,
+  type CalendarEvent,
+} from "../src/utils/calendarLinks";
+import { buildEventIcalUrl } from "../src/utils/eventUrls";
+
+const baseEvent: CalendarEvent = {
+  id: "216a13d3-99dd-4266-9ec6-ccdc119423c9",
+  title: "UtahJS SLC Meetup - Intro to WASM",
+  event_date: "2026-06-17",
+  start_time: "19:00:00",
+  end_time: "21:00:00",
+  venue_name: "Software Technology Group",
+  address_line_1: "555 S 300 E",
+  city: "Salt Lake City",
+  state_province: "UT",
+  postal_code: "84111",
+  country: "USA",
+  link: "https://www.meetup.com/utahjs/events/307276974",
+  description: "Join us in person or on Zoom!",
+};
+
+describe("validateHttpUrl", () => {
+  it("accepts https URLs", () => {
+    expect(validateHttpUrl("https://example.com")).toBe("https://example.com");
+  });
+  it("accepts http URLs", () => {
+    expect(validateHttpUrl("http://example.com")).toBe("http://example.com");
+  });
+  it("rejects javascript: URLs", () => {
+    expect(validateHttpUrl("javascript:alert(1)")).toBe("");
+  });
+  it("rejects data: URLs", () => {
+    expect(validateHttpUrl("data:text/html,<script>alert(1)</script>")).toBe("");
+  });
+  it("rejects file: URLs", () => {
+    expect(validateHttpUrl("file:///etc/passwd")).toBe("");
+  });
+  it("handles null/undefined", () => {
+    expect(validateHttpUrl(null)).toBe("");
+    expect(validateHttpUrl(undefined)).toBe("");
+    expect(validateHttpUrl("")).toBe("");
+  });
+});
+
+describe("getEventEndTime", () => {
+  it("slices HH:MM:SS to HH:MM when end_time provided", () => {
+    expect(getEventEndTime("19:00:00", "21:00:00")).toBe("21:00");
+  });
+  it("falls back to start+1h when end_time missing", () => {
+    expect(getEventEndTime("19:00:00", undefined)).toBe("20:00");
+  });
+  it("handles HH:MM:SS input without double-seconds corruption", () => {
+    // The RSS/iCal double-seconds regression (2026-04-04):
+    // ensure we don't produce "20:00:00:00" from "19:00:00" input.
+    const result = getEventEndTime("19:00:00", undefined);
+    expect(result).toBe("20:00");
+    expect(result).not.toMatch(/:\d+:\d+:\d+/);
+  });
+  it("produces same result for HH:MM and HH:MM:SS inputs", () => {
+    expect(getEventEndTime("19:00", undefined)).toBe(getEventEndTime("19:00:00", undefined));
+  });
+  it("wraps past midnight", () => {
+    expect(getEventEndTime("23:30:00", undefined)).toBe("00:30");
+  });
+  it("returns undefined when start_time missing", () => {
+    expect(getEventEndTime(undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe("toGooglePayload", () => {
+  it("builds timed payload for events with start_time", () => {
+    const payload = toGooglePayload(baseEvent);
+    expect(payload.kind).toBe("timed");
+    if (payload.kind === "timed") {
+      expect(payload.start).toBe("20260617T190000");
+      expect(payload.end).toBe("20260617T210000");
+      expect(payload.tz).toBe("America/Denver");
+    }
+  });
+
+  it("builds allDay payload for events without start_time", () => {
+    const payload = toGooglePayload({ ...baseEvent, start_time: undefined });
+    expect(payload.kind).toBe("allDay");
+    if (payload.kind === "allDay") {
+      expect(payload.start).toBe("20260617");
+      expect(payload.end).toBe("20260618");
+    }
+  });
+
+  it("handles HH:MM:SS start_time without double-seconds", () => {
+    const payload = toGooglePayload({ ...baseEvent, start_time: "19:00:00", end_time: undefined });
+    if (payload.kind === "timed") {
+      expect(payload.start).toBe("20260617T190000");
+      expect(payload.end).toBe("20260617T200000");
+    }
+  });
+});
+
+describe("buildGoogleCalendarUrl", () => {
+  it("includes action=TEMPLATE and text", () => {
+    const url = buildGoogleCalendarUrl(baseEvent);
+    expect(url).toContain("calendar.google.com/calendar/render");
+    expect(url).toContain("action=TEMPLATE");
+    expect(url).toContain("text=UtahJS+SLC+Meetup+-+Intro+to+WASM");
+  });
+
+  it("includes ctz=America/Denver for timed events", () => {
+    const url = buildGoogleCalendarUrl(baseEvent);
+    expect(url).toContain("ctz=America%2FDenver");
+  });
+
+  it("omits ctz for all-day events", () => {
+    const url = buildGoogleCalendarUrl({ ...baseEvent, start_time: undefined });
+    expect(url).not.toContain("ctz=");
+  });
+
+  it("preserves unencoded slash in dates param", () => {
+    const url = buildGoogleCalendarUrl(baseEvent);
+    expect(url).toMatch(/dates=20260617T190000\/20260617T210000/);
+  });
+
+  it("uses exclusive end date for all-day events", () => {
+    const url = buildGoogleCalendarUrl({ ...baseEvent, start_time: undefined });
+    expect(url).toMatch(/dates=20260617\/20260618/);
+  });
+
+  it("routes physical address into location", () => {
+    const url = buildGoogleCalendarUrl(baseEvent);
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("location")).toContain("Salt Lake City");
+  });
+
+  it("routes event.link into location for online-only events", () => {
+    const onlineEvent: CalendarEvent = {
+      ...baseEvent,
+      venue_name: "Zoom",
+      address_line_1: undefined,
+      city: undefined,
+      state_province: undefined,
+      postal_code: undefined,
+      country: undefined,
+      location: "Zoom",
+      link: "https://zoom.us/j/abc123",
+    };
+    const url = buildGoogleCalendarUrl(onlineEvent);
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("location")).toBe("https://zoom.us/j/abc123");
+  });
+
+  it("does not embed javascript: URLs", () => {
+    const maliciousEvent: CalendarEvent = {
+      ...baseEvent,
+      link: "javascript:alert(1)",
+    };
+    const url = buildGoogleCalendarUrl(maliciousEvent);
+    expect(url).not.toContain("javascript");
+    expect(decodeURIComponent(url)).not.toContain("javascript:");
+  });
+
+  it("URL-encodes commas and ampersands in title", () => {
+    const url = buildGoogleCalendarUrl({
+      ...baseEvent,
+      title: "Dinner, Drinks & Code",
+    });
+    const params = new URLSearchParams(url.split("?")[1]);
+    expect(params.get("text")).toBe("Dinner, Drinks & Code");
+  });
+
+  it("truncates description to 1500 chars", () => {
+    const longDescription = "x".repeat(2000);
+    const url = buildGoogleCalendarUrl({ ...baseEvent, description: longDescription });
+    const decoded = decodeURIComponent(url);
+    const detailsMatch = decoded.match(/details=([^&]*)/);
+    expect(detailsMatch).not.toBeNull();
+    // 1500 x's plus the source URL and a blank line
+    expect(detailsMatch![1].length).toBeLessThan(2000);
+  });
+});
+
+describe("getCalendarLocation", () => {
+  it("returns full address for in-person events", () => {
+    expect(getCalendarLocation(baseEvent)).toBe("555 S 300 E, Salt Lake City, UT, 84111, USA");
+  });
+
+  it("returns validated link for online-only events", () => {
+    const online: CalendarEvent = {
+      ...baseEvent,
+      venue_name: "Zoom",
+      address_line_1: undefined,
+      city: undefined,
+      state_province: undefined,
+      postal_code: undefined,
+      country: undefined,
+      location: "Zoom",
+    };
+    expect(getCalendarLocation(online)).toBe(baseEvent.link);
+  });
+
+  it("returns empty string for online event with invalid link", () => {
+    const online: CalendarEvent = {
+      ...baseEvent,
+      venue_name: "Zoom",
+      address_line_1: undefined,
+      city: undefined,
+      state_province: undefined,
+      postal_code: undefined,
+      country: undefined,
+      location: "Zoom",
+      link: "javascript:alert(1)",
+    };
+    expect(getCalendarLocation(online)).toBe("");
+  });
+});
+
+describe("buildEventIcalUrl", () => {
+  it("builds a URL pointing at the generate-ical function with event param", () => {
+    const url = buildEventIcalUrl("abc-123");
+    expect(url).toContain("/functions/v1/generate-ical?event=abc-123");
+  });
+
+  it("URL-encodes the event id", () => {
+    const url = buildEventIcalUrl("abc&def");
+    expect(url).toContain("event=abc%26def");
+  });
+});


### PR DESCRIPTION
## Summary

Adds a three-dot menu to the top-right of every event card with three actions: **Add to Google Calendar**, **Add to Apple Calendar**, and **Download .ics**.
Per-event calendar export was previously not possible — users had to subscribe to the bulk feed.

- Google Calendar: client-side URL to `calendar.google.com/calendar/render?action=TEMPLATE&...` with `ctz=America/Denver`, opens in a new tab.
Discriminated-union builder handles timed vs. all-day events correctly.
Function. The imperative detached-anchor pattern (`document.createElement("a").click()` inside `DropdownMenuItem.onSelect`) is required because iOS Safari will
 abort the navigation when Radix unmounts the menu, and blob/data URIs can't hand off to Calendar.app on iOS 15+.

## Changes

- `src/components/EventsTimeline.tsx` — inline `AddToCalendarMenu` component, top-right absolute-positioned on each card, 44px touch target, subtle inset chip styling (`bg-white/5 + border-white/10 + text-white/70`)
- `src/utils/calendarLinks.ts` (new) — `buildGoogleCalendarUrl`, `toGooglePayload` (discriminated union), `getEventEndTime`, `buildFullAddress`, `getCalendarLocation`, `validateHttpUrl`
- `src/utils/eventUrls.ts` — new `buildEventIcalUrl(eventId)` sibling of `generateICalUrl`
- `src/types/events.ts` + `src/pages/Index.tsx` — `end_time` added to shared type and selected in the events query
- `supabase/functions/generate-ical/index.ts` — new `?event=<id>` branch at top of handler:
  - UUID regex + 36-char length cap → 400 on malformed
  - `status = 'approved'` on event **and** `groups.status = 'approved'` parity with bulk path
  - `validateHttpUrl` (rejects `javascript:` / `data:` / `file:`) applied to `event.link` before it lands in any calendar field
  - `Cache-Control: public, max-age=3600, s-maxage=86400`
  - `Content-Disposition: attachment; filename="<event-id>.ics"`
  - Existing bulk code path factored through shared `renderVEvent` / `wrapVCalendar` helpers (behavior unchanged)
- `tests/calendarLinks.test.ts` (new, 30 tests) — Google URL shape (timed + all-day), `ctz` param, dates slash preservation, online-only location routing, `javascript:` link rejection, HH:MM:SS input handling (guards against the 2026-04-04 RSS/iCal double-seconds regression)

## Testing

- `npm test` → 53/53 pass (30 new)
- `npx tsc --noEmit` → clean
- `npm run build` → clean
- `npm run lint` → fails on a pre-existing `@typescript-eslint/no-unused-expressions` config issue on untouched file `lib/feedUtils.ts`; same failure on `main` before this branch

## Deploy required

**The Apple Calendar / Download .ics items will NOT work until the Edge Function is redeployed.** The current prod function doesn't know about `?event=<id>` and silently falls through to the bulk feed.

```
supabase functions deploy generate-ical
```

Verify with:
```
curl -I "https://gocvjqlltcxtcrwvfwez.supabase.co/functions/v1/generate-ical?event=nonexistent"
```
Expect 400 Bad Request. Before deploy: 200 with the bulk feed.

## Post-Deploy Monitoring & Validation

- **What to monitor**
  - Supabase Function logs for `generate-ical` — watch for 5xx error rate spike
  - CDN hit rate on `?event=<id>` requests (should climb toward cache-hit-heavy over first hour)
- **Validation checks**
  - `curl -I "…/generate-ical?event=<known-approved-id>"` → 200 with `Content-Type: text/calendar; charset=utf-8`
  - `curl -I "…/generate-ical?event=00000000-0000-0000-0000-000000000000"` → 404
  - `curl -I "…/generate-ical?event=not-a-uuid"` → 400
  - `curl "…/generate-ical"` (no event param) → unchanged bulk feed (backward compatibility)
- **Expected healthy behavior**
  - 2xx rate > 99% on `?event=<id>` requests for valid UUIDs
  - 4xx on malformed/missing as designed
  - Bulk feed latency unchanged
- **Failure signal / rollback trigger**
  - 5xx rate > 1% on any path → redeploy previous revision or revert this PR
  - Bulk feed latency regression > 20% → investigate shared `renderVEvent` refactor
- **Validation window & owner**
  - Window: first 24h post-deploy; owner: whoever deploys

## Manual QA checklist (please verify before merge)

- [ ] Three-dot icon visible in top-right of each event card (subtle chip, hover brightens)
- [ ] Menu opens, three items present with correct labels
- [ ] Add to Google Calendar → new tab opens `calendar.google.com/calendar/render?…` with correct title, dates in Mountain Time, address/link in location
- [ ] Add to Apple Calendar / Download .ics → downloads `<event-id>.ics` containing ONE event
- [ ] Online-only event (e.g., Zoom meetup) → meeting link shows up in calendar location, not an empty address
- [ ] All-day event (no start_time) → correct all-day entry in both providers
- [ ] iOS Safari: Calendar.app import sheet appears (vs. a blank tab)
- [ ] Existing bulk subscribe URL still works (no regression on the filter-panel "Subscribe" flow)

## Deferred drive-by fixes (separate issues)

These were identified during planning but intentionally scoped out of this PR to minimize blast radius. Each should be its own follow-up:

1. `TZID=us-mountain` → `TZID=America/Denver` (non-standard value; likely cause of iOS time-display weirdness for bulk subscribers)
2. Deprecated `import { serve }` from `deno.land/std@0.171.0` → native `Deno.serve`
3. CRLF line endings (`\r\n`) + 75-octet line folding per RFC 5545
4. Escape `groupName` and `tags.join(", ")` through `escapeICalText` in the bulk path (existing iCal injection bug)
5. Extract duplicate `Event` interface out of `EventsTimeline.tsx` and `EventsTable.tsx` in favor of shared `src/types/events.ts`
6. Mirror `?event=<id>` on `generate-rss` for parity

## Origin

Plan: `docs/plans/2026-04-19-001-feat-add-to-calendar-dropdown-plan.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
