### PR TITLE
feat(past-events): add past events page with video recording submissions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import Past from "./pages/Past";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/past" element={<Past />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,5 @@
 
+import { Link } from "react-router-dom";
 import { CalendarDays, Github } from "lucide-react";
 
 export default function Navbar() {
@@ -6,13 +7,19 @@ export default function Navbar() {
     <div className="w-full">
       <div className="max-w-7xl mx-auto px-4">
         <nav className="w-full flex justify-between items-center py-6">
-          <div className="flex items-center gap-3">
+          <Link to="/" className="flex items-center gap-3">
             <CalendarDays className="text-primary w-8 h-8" />
             <span className="text-xl font-extrabold tracking-tight text-white">
               UtahDev.events
             </span>
-          </div>
+          </Link>
           <div className="flex items-center gap-5">
+            <Link
+              to="/past"
+              className="text-sm text-muted-foreground hover:text-white story-link"
+            >
+              Past events
+            </Link>
             <a
               href="https://github.com/forgeutah"
               target="_blank"

--- a/src/components/PastEventsTimeline.tsx
+++ b/src/components/PastEventsTimeline.tsx
@@ -1,0 +1,253 @@
+import { useState } from "react";
+import { format, parseISO } from "date-fns";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { MapPin, Clock, ExternalLink, PlayCircle, Upload } from "lucide-react";
+import SubmitRecordingModal from "./SubmitRecordingModal";
+import { parseRecordingHostname } from "@/utils/recordingUrl";
+import { RECORDING_STATUS, type Event } from "@/types/events";
+
+interface PastEventsTimelineProps {
+  events: Event[];
+  isLoading: boolean;
+  error: unknown;
+  visibleCount: number;
+  onShowMore: () => void;
+}
+
+const formatPastEventTime = (eventDate: string, startTime?: string) => {
+  const date = parseISO(eventDate);
+  let timeDisplay = "";
+  if (startTime) {
+    const [hours, minutes] = startTime.slice(0, 5).split(":").map(Number);
+    const dt = new Date(date);
+    dt.setHours(hours, minutes);
+    timeDisplay = format(dt, "h:mm a");
+  }
+  return { date, timeDisplay };
+};
+
+const buildFullAddress = (event: Event) => {
+  const parts = [];
+  if (event.address_line_1) parts.push(event.address_line_1);
+  if (event.address_line_2) parts.push(event.address_line_2);
+  if (event.city) parts.push(event.city);
+  if (event.state_province) parts.push(event.state_province);
+  if (event.postal_code) parts.push(event.postal_code);
+  if (event.country) parts.push(event.country);
+  return parts.join(", ");
+};
+
+const getEventTags = (event: Event) => {
+  if (event.tags && event.tags.length > 0) return event.tags;
+  return event.groups?.tags || [];
+};
+
+export function PastEventsTimeline({ events, isLoading, error, visibleCount, onShowMore }: PastEventsTimelineProps) {
+  const [submitEvent, setSubmitEvent] = useState<Event | null>(null);
+
+  if (isLoading) {
+    return <div className="py-8 text-center text-muted-foreground">Loading events...</div>;
+  }
+  if (error) {
+    return <div className="py-8 text-center text-red-500">Failed to load events.</div>;
+  }
+  if (events.length === 0) {
+    return (
+      <div className="py-8 text-center text-muted-foreground">
+        No past events match your current filters.
+      </div>
+    );
+  }
+
+  const visibleEvents = events.slice(0, visibleCount);
+  const hasMore = events.length > visibleCount;
+
+  // Group by date; sort keys DESC (newest past first).
+  const grouped = visibleEvents.reduce((groups, event) => {
+    const dateKey = event.event_date;
+    if (!groups[dateKey]) {
+      groups[dateKey] = { date: parseISO(dateKey), events: [] };
+    }
+    groups[dateKey].events.push(event);
+    return groups;
+  }, {} as Record<string, { date: Date; events: Event[] }>);
+
+  Object.values(grouped).forEach((group) => {
+    group.events.sort((a, b) => {
+      if (!a.start_time && !b.start_time) return 0;
+      if (!a.start_time) return 1;
+      if (!b.start_time) return -1;
+      return a.start_time.localeCompare(b.start_time);
+    });
+  });
+
+  const groupedArray = Object.entries(grouped).sort(([a], [b]) => b.localeCompare(a));
+
+  return (
+    <>
+      <div className="space-y-8 relative">
+        {groupedArray.length > 1 && (
+          <div className="absolute left-[3px] top-[32px] w-px h-full">
+            <div
+              className="w-full border-l-2 border-dotted border-white/20"
+              style={{
+                height: "calc(100% - 120px)",
+                background:
+                  "linear-gradient(to bottom, rgba(255,255,255,0.2) 0%, rgba(255,255,255,0.2) 80%, transparent 100%)",
+                maskImage:
+                  "repeating-linear-gradient(to bottom, transparent 0px, transparent 4px, black 4px, black 8px)",
+                WebkitMaskImage:
+                  "repeating-linear-gradient(to bottom, transparent 0px, transparent 4px, black 4px, black 8px)",
+              }}
+            />
+          </div>
+        )}
+
+        {groupedArray.map(([dateKey, { date, events: dayEvents }]) => (
+          <div key={dateKey} className="relative">
+            <div className="flex items-center gap-4 mb-6">
+              <div className="w-2 h-2 bg-primary rounded-full flex-shrink-0 relative z-10" />
+              <div className="text-white">
+                <div className="text-lg font-semibold">
+                  {format(date, "MMM d, yyyy")}{" "}
+                  <span className="text-gray-400 font-normal">{format(date, "EEEE")}</span>
+                </div>
+              </div>
+            </div>
+
+            <div className="ml-6 space-y-4">
+              {dayEvents.map((event) => {
+                const { timeDisplay } = formatPastEventTime(event.event_date, event.start_time);
+                const displayLocation = event.venue_name || event.location;
+                const eventTags = getEventTags(event);
+                const hasApprovedRecording =
+                  event.recording_status === RECORDING_STATUS.Approved && event.recording_url;
+                const hasPendingRecording = event.recording_status === RECORDING_STATUS.Pending;
+                const recordingHost = parseRecordingHostname(event.recording_url);
+
+                return (
+                  <div
+                    key={event.id}
+                    className="bg-gradient-to-br from-[#22243A]/80 via-[#23283B]/80 to-[#383B53]/80 backdrop-blur-sm border border-white/10 rounded-xl p-6 hover:border-primary/30 transition-all duration-200"
+                  >
+                    {timeDisplay && (
+                      <div className="flex items-center gap-2 text-sm text-primary mb-3">
+                        <Clock className="w-4 h-4" />
+                        <span className="font-medium">{timeDisplay}</span>
+                      </div>
+                    )}
+
+                    {event.groups?.name && (
+                      <div className="text-sm text-muted-foreground mb-1">{event.groups.name}</div>
+                    )}
+
+                    <h3 className="text-xl font-semibold text-white mb-2">
+                      {event.link ? (
+                        <a
+                          href={event.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-white hover:text-primary cursor-pointer transition-colors inline-flex items-center gap-2"
+                        >
+                          {event.title}
+                          <ExternalLink className="w-4 h-4" />
+                        </a>
+                      ) : (
+                        event.title
+                      )}
+                    </h3>
+
+                    {event.description && (
+                      <p className="text-muted-foreground text-sm mb-4 line-clamp-2">
+                        {event.description}
+                      </p>
+                    )}
+
+                    <div className="flex items-center gap-2 text-sm text-muted-foreground mb-4">
+                      <MapPin className="w-4 h-4" />
+                      <span>{displayLocation || "TBD"}</span>
+                    </div>
+
+                    {eventTags.length > 0 && (
+                      <div className="flex flex-wrap gap-2 mb-4">
+                        {eventTags.map((tag, index) => (
+                          <Badge
+                            key={index}
+                            variant="outline"
+                            className="text-xs bg-transparent border-primary/40 text-primary/90 px-2"
+                          >
+                            {tag}
+                          </Badge>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* Recording actions */}
+                    <div className="flex flex-wrap items-center gap-3 pt-2 border-t border-white/5">
+                      {hasApprovedRecording ? (
+                        <>
+                          <Button asChild variant="outline" size="sm" className="border-primary/60 text-primary hover:bg-primary hover:text-black">
+                            <a
+                              href={event.recording_url ?? "#"}
+                              target="_blank"
+                              rel="noopener noreferrer"
+                              aria-label={`Watch recording of ${event.title} on ${recordingHost}`}
+                            >
+                              <PlayCircle className="w-4 h-4 mr-1" />
+                              Watch Recording
+                            </a>
+                          </Button>
+                          {recordingHost && (
+                            <span className="text-xs text-muted-foreground">{recordingHost}</span>
+                          )}
+                        </>
+                      ) : (
+                        <>
+                          {hasPendingRecording && (
+                            <Badge variant="outline" className="border-yellow-400/50 text-yellow-200">
+                              Recording pending review
+                            </Badge>
+                          )}
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => setSubmitEvent(event)}
+                          >
+                            <Upload className="w-4 h-4 mr-1" />
+                            Submit Recording
+                          </Button>
+                        </>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        ))}
+
+        {hasMore && (
+          <div className="flex justify-center mt-6">
+            <button
+              onClick={onShowMore}
+              className="px-6 py-2 text-sm bg-primary/10 text-primary border border-primary rounded-md hover:bg-primary hover:text-black transition-colors"
+            >
+              Show More ({events.length - visibleCount} remaining)
+            </button>
+          </div>
+        )}
+      </div>
+
+      {submitEvent && (
+        <SubmitRecordingModal
+          open={true}
+          onOpenChange={(o) => {
+            if (!o) setSubmitEvent(null);
+          }}
+          event={submitEvent}
+        />
+      )}
+    </>
+  );
+}

--- a/src/components/SubmitRecordingModal.tsx
+++ b/src/components/SubmitRecordingModal.tsx
@@ -1,0 +1,207 @@
+import { useEffect, useRef, useState } from "react";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useToast } from "@/hooks/use-toast";
+import { supabase } from "@/integrations/supabase/client";
+import { isValidRecordingUrl } from "@/utils/recordingUrl";
+import { RECORDING_STATUS, type Event } from "@/types/events";
+
+type SubmitRecordingEvent = Pick<Event, "id" | "title" | "link" | "recording_status">;
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  event: SubmitRecordingEvent;
+}
+
+const MIN_OPEN_MS = 2000;
+
+export default function SubmitRecordingModal({ open, onOpenChange, event }: Props) {
+  const [formData, setFormData] = useState({ recording_url: "", contact_email: "", website: "" });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const submittingRef = useRef(false);
+  const mountedRef = useRef(true);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const openedAtRef = useRef<number>(Date.now());
+  const { toast } = useToast();
+  const qc = useQueryClient();
+
+  useEffect(() => () => {
+    mountedRef.current = false;
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      openedAtRef.current = Date.now();
+      if (resetTimerRef.current) {
+        clearTimeout(resetTimerRef.current);
+        resetTimerRef.current = null;
+      }
+    }
+  }, [open]);
+
+  const handleClose = () => {
+    onOpenChange(false);
+    if (resetTimerRef.current) clearTimeout(resetTimerRef.current);
+    resetTimerRef.current = setTimeout(() => {
+      if (!mountedRef.current) return;
+      setFormData({ recording_url: "", contact_email: "", website: "" });
+      setIsSubmitting(false);
+    }, 200);
+  };
+
+  const submit = useMutation({
+    mutationFn: async ({ id, url }: { id: string; url: string }) => {
+      const { data, error } = await supabase.functions.invoke("submit-recording", {
+        body: { event_id: id, recording_url: url },
+      });
+      if (error) throw new Error(error.message || "Submission failed");
+      if (data && typeof data === "object" && "error" in data && data.error) {
+        throw new Error(String(data.error));
+      }
+    },
+    onMutate: async ({ id, url }) => {
+      await qc.cancelQueries({ queryKey: ["past-events"] });
+      const prev = qc.getQueryData<Event[]>(["past-events"]);
+      qc.setQueryData<Event[]>(["past-events"], (old) =>
+        (old ?? []).map((e) =>
+          e.id === id ? { ...e, recording_url: url, recording_status: RECORDING_STATUS.Pending } : e,
+        ),
+      );
+      return { prev };
+    },
+    onError: (_err, _vars, ctx) => {
+      if (ctx?.prev !== undefined) {
+        qc.setQueryData(["past-events"], ctx.prev);
+      }
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ["past-events"] });
+    },
+  });
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+
+    if (submittingRef.current) return;
+    submittingRef.current = true;
+    setIsSubmitting(true);
+
+    const url = formData.recording_url.trim();
+
+    // Honeypot tripped — pretend success, no network call.
+    if (formData.website) {
+      toast({ title: "Thanks — pending review" });
+      submittingRef.current = false;
+      handleClose();
+      return;
+    }
+
+    // Bot time-to-submit gate.
+    if (Date.now() - openedAtRef.current < MIN_OPEN_MS) {
+      toast({ title: "Thanks — pending review" });
+      submittingRef.current = false;
+      handleClose();
+      return;
+    }
+
+    if (!isValidRecordingUrl(url)) {
+      toast({
+        title: "Invalid URL",
+        description: "Use a https link from YouTube, Vimeo, or Loom.",
+        variant: "destructive",
+      });
+      submittingRef.current = false;
+      setIsSubmitting(false);
+      return;
+    }
+
+    if (event.link && url === event.link) {
+      toast({
+        title: "That's the event page, not a recording",
+        description: "Please paste the actual YouTube/Vimeo/Loom URL.",
+        variant: "destructive",
+      });
+      submittingRef.current = false;
+      setIsSubmitting(false);
+      return;
+    }
+
+    try {
+      await submit.mutateAsync({ id: event.id, url });
+      if (!mountedRef.current) return;
+      toast({
+        variant: "default",
+        title: "Thanks — pending review",
+        description:
+          "Your submission will appear on the Past Events page once an admin approves it.",
+      });
+      handleClose();
+    } catch (err) {
+      if (!mountedRef.current) return;
+      toast({
+        variant: "destructive",
+        title: "Could not submit",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      submittingRef.current = false;
+      if (mountedRef.current) setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>Submit Recording</DialogTitle>
+          <DialogDescription>
+            Share a video recording for <span className="font-medium">{event.title}</span>.
+            Submissions are reviewed before they appear publicly.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <label className="text-sm text-muted-foreground" htmlFor="recording-url">
+            Recording URL (YouTube, Vimeo, or Loom)
+          </label>
+          <Input
+            id="recording-url"
+            type="url"
+            placeholder="https://youtube.com/watch?v=..."
+            value={formData.recording_url}
+            required
+            onChange={(e) => setFormData((v) => ({ ...v, recording_url: e.target.value }))}
+          />
+          <Input
+            type="email"
+            placeholder="Contact email (optional, if we have questions)"
+            value={formData.contact_email}
+            onChange={(e) => setFormData((v) => ({ ...v, contact_email: e.target.value }))}
+          />
+          {/* Honeypot: hidden from real users, crawled by bots. */}
+          <input
+            type="text"
+            name="website"
+            tabIndex={-1}
+            autoComplete="off"
+            aria-hidden="true"
+            className="sr-only"
+            value={formData.website}
+            onChange={(e) => setFormData((v) => ({ ...v, website: e.target.value }))}
+          />
+          <DialogFooter>
+            <Button variant="outline" type="button" onClick={handleClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Submitting…" : "Submit"}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -31,6 +31,8 @@ export type Database = {
           link: string | null
           location: string | null
           postal_code: string | null
+          recording_status: string | null
+          recording_url: string | null
           remote_id: string | null
           start_time: string | null
           state_province: string | null
@@ -55,6 +57,8 @@ export type Database = {
           link?: string | null
           location?: string | null
           postal_code?: string | null
+          recording_status?: string | null
+          recording_url?: string | null
           remote_id?: string | null
           start_time?: string | null
           state_province?: string | null
@@ -79,6 +83,8 @@ export type Database = {
           link?: string | null
           location?: string | null
           postal_code?: string | null
+          recording_status?: string | null
+          recording_url?: string | null
           remote_id?: string | null
           start_time?: string | null
           state_province?: string | null

--- a/src/pages/Past.tsx
+++ b/src/pages/Past.tsx
@@ -1,0 +1,115 @@
+import { useMemo, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { supabase } from "@/integrations/supabase/client";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import { PastEventsTimeline } from "@/components/PastEventsTimeline";
+import { Switch } from "@/components/ui/switch";
+import { Label } from "@/components/ui/label";
+import { RECORDING_STATUS, type Event } from "@/types/events";
+import { todayInDenver } from "@/utils/pastEvents";
+
+async function fetchPastEvents() {
+  const { data, error } = await supabase
+    .from("events")
+    .select(`
+      id,
+      title,
+      event_date,
+      start_time,
+      location,
+      venue_name,
+      address_line_1,
+      address_line_2,
+      city,
+      state_province,
+      postal_code,
+      country,
+      link,
+      status,
+      group_id,
+      description,
+      tags,
+      recording_url,
+      recording_status,
+      groups (
+        name,
+        status,
+        tags
+      )
+    `)
+    .eq("status", "approved")
+    .lt("event_date", todayInDenver())
+    .order("event_date", { ascending: false });
+
+  if (error) throw error;
+
+  return (data ?? []).filter((e: Event) => !e.groups || e.groups.status === "approved");
+}
+
+const INITIAL_VISIBLE = 50;
+
+const Past = () => {
+  const [showAll, setShowAll] = useState(false);
+  const [visibleCount, setVisibleCount] = useState(INITIAL_VISIBLE);
+
+  const { data: events, isLoading, error } = useQuery({
+    queryKey: ["past-events"],
+    queryFn: fetchPastEvents,
+    staleTime: 5 * 60 * 1000,
+    gcTime: 30 * 60 * 1000,
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+
+  const displayedEvents = useMemo(() => {
+    const all = (events as Event[] | undefined) ?? [];
+    if (showAll) return all;
+    return all.filter(
+      (e) => e.recording_status === RECORDING_STATUS.Approved && e.recording_url,
+    );
+  }, [events, showAll]);
+
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-[#1A1F2C] to-[#23283B]">
+      <Navbar />
+      <main className="max-w-7xl mx-auto px-4 py-10">
+        <header className="mb-8">
+          <h1 className="text-3xl font-extrabold tracking-tight text-white mb-2">
+            Past Events
+          </h1>
+          <p className="text-muted-foreground text-sm max-w-2xl">
+            A library of recordings from past Utah dev events. See one that's missing?
+            Click <span className="font-medium">Submit Recording</span> on the event's card
+            to share the link — submissions are reviewed before going public.
+          </p>
+        </header>
+
+        <div className="flex items-center gap-3 mb-8 p-4 rounded-lg bg-white/5 border border-white/10">
+          <Switch
+            id="show-all-past"
+            checked={showAll}
+            onCheckedChange={setShowAll}
+          />
+          <Label htmlFor="show-all-past" className="text-sm text-white cursor-pointer">
+            Include events without recordings
+          </Label>
+          <span className="ml-auto text-xs text-muted-foreground">
+            {displayedEvents.length} {displayedEvents.length === 1 ? "event" : "events"}
+          </span>
+        </div>
+
+        <PastEventsTimeline
+          events={displayedEvents}
+          isLoading={isLoading}
+          error={error}
+          visibleCount={visibleCount}
+          onShowMore={() => setVisibleCount((v) => v + INITIAL_VISIBLE)}
+        />
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default Past;

--- a/src/types/events.ts
+++ b/src/types/events.ts
@@ -1,4 +1,10 @@
 
+export const RECORDING_STATUS = {
+  Pending: 'pending',
+  Approved: 'approved',
+} as const;
+export type RecordingStatus = typeof RECORDING_STATUS[keyof typeof RECORDING_STATUS];
+
 export interface Event {
   id: string;
   title: string;
@@ -15,6 +21,8 @@ export interface Event {
   link?: string;
   description?: string;
   tags?: string[];
+  recording_url?: string | null;
+  recording_status?: RecordingStatus | null;
   groups?: {
     name: string;
     status: string;

--- a/src/utils/pastEvents.ts
+++ b/src/utils/pastEvents.ts
@@ -1,0 +1,14 @@
+const DENVER_DATE_FMT = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'America/Denver',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+});
+
+export function todayInDenver(now: Date = new Date()): string {
+  return DENVER_DATE_FMT.format(now);
+}
+
+export function isPastEvent(event: { event_date: string }, today: string = todayInDenver()): boolean {
+  return event.event_date < today;
+}

--- a/src/utils/recordingUrl.ts
+++ b/src/utils/recordingUrl.ts
@@ -1,0 +1,32 @@
+export const ALLOWED_RECORDING_HOSTS: ReadonlySet<string> = new Set([
+  'youtube.com',
+  'www.youtube.com',
+  'm.youtube.com',
+  'youtu.be',
+  'vimeo.com',
+  'www.vimeo.com',
+  'player.vimeo.com',
+  'loom.com',
+  'www.loom.com',
+]);
+
+export function isValidRecordingUrl(url: string): boolean {
+  if (!url || url.length > 2000) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') return false;
+  return ALLOWED_RECORDING_HOSTS.has(parsed.hostname.toLowerCase());
+}
+
+export function parseRecordingHostname(url: string | null | undefined): string | null {
+  if (!url) return null;
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return null;
+  }
+}

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -15,3 +15,6 @@ verify_jwt = false
 
 [functions.scrape-single-meetup]
 verify_jwt = false
+
+[functions.submit-recording]
+verify_jwt = false

--- a/supabase/functions/scrape-meetup-events/index.ts
+++ b/supabase/functions/scrape-meetup-events/index.ts
@@ -140,6 +140,9 @@ serve(async (req) => {
                 continue
               }
 
+              // DO NOT add `recording_url` or `recording_status` to this object.
+              // These columns hold user-submitted video links and must not be
+              // clobbered on re-scrape. See tests/scraperFieldLists.test.ts.
               const eventData = {
                 group_id: group.id,
                 title: scrapedEvent.title,

--- a/supabase/functions/scrape-misc-websites/index.ts
+++ b/supabase/functions/scrape-misc-websites/index.ts
@@ -215,6 +215,9 @@ serve(async (req) => {
               }
             }
 
+          // DO NOT add `recording_url` or `recording_status` to this object.
+          // These columns hold user-submitted video links and must not be
+          // clobbered on re-scrape. See tests/scraperFieldLists.test.ts.
           const eventData = {
             group_id: groupId,
             title: scrapedEvent.title,

--- a/supabase/functions/scrape-single-meetup/index.ts
+++ b/supabase/functions/scrape-single-meetup/index.ts
@@ -170,6 +170,9 @@ serve(async (req) => {
           continue
         }
 
+        // DO NOT add `recording_url` or `recording_status` to this object.
+        // These columns hold user-submitted video links and must not be
+        // clobbered on re-scrape. See tests/scraperFieldLists.test.ts.
         const eventData = {
           group_id: group_id,
           title: scrapedEvent.title,

--- a/supabase/functions/scrape-university-events/index.ts
+++ b/supabase/functions/scrape-university-events/index.ts
@@ -177,6 +177,9 @@ serve(async (req) => {
             continue
           }
 
+          // DO NOT add `recording_url` or `recording_status` to this object.
+          // These columns hold user-submitted video links and must not be
+          // clobbered on re-scrape. See tests/scraperFieldLists.test.ts.
           const eventData = {
             group_id: groupId,
             title: scrapedEvent.title,

--- a/supabase/functions/submit-recording/index.ts
+++ b/supabase/functions/submit-recording/index.ts
@@ -1,0 +1,111 @@
+import { serve } from "https://deno.land/std@0.171.0/http/server.ts";
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+// Keep in sync with src/utils/recordingUrl.ts ALLOWED_RECORDING_HOSTS.
+const ALLOWED_HOSTS = new Set([
+  "youtube.com",
+  "www.youtube.com",
+  "m.youtube.com",
+  "youtu.be",
+  "vimeo.com",
+  "www.vimeo.com",
+  "player.vimeo.com",
+  "loom.com",
+  "www.loom.com",
+]);
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...corsHeaders, "Content-Type": "application/json" },
+  });
+}
+
+serve(async (req: Request) => {
+  if (req.method === "OPTIONS") {
+    return new Response(null, { headers: corsHeaders });
+  }
+  if (req.method !== "POST") {
+    return json({ error: "Method not allowed" }, 405);
+  }
+
+  let body: { event_id?: string; recording_url?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return json({ error: "Invalid JSON" }, 400);
+  }
+
+  const eventId = body.event_id;
+  const recordingUrl = body.recording_url;
+
+  if (!eventId || !UUID_RE.test(eventId)) {
+    return json({ error: "Invalid event_id" }, 400);
+  }
+  if (!recordingUrl || typeof recordingUrl !== "string") {
+    return json({ error: "Missing recording_url" }, 400);
+  }
+  if (recordingUrl.length > 2000) {
+    return json({ error: "URL too long" }, 400);
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(recordingUrl);
+  } catch {
+    return json({ error: "Invalid URL" }, 400);
+  }
+  if (parsed.protocol !== "https:") {
+    return json({ error: "URL must use https" }, 400);
+  }
+  if (!ALLOWED_HOSTS.has(parsed.hostname.toLowerCase())) {
+    return json({ error: "Host not allowed" }, 400);
+  }
+
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
+  const supabaseUrl = Deno.env.get("SUPABASE_URL") ?? "https://gocvjqljtcxtcrwvfwez.supabase.co";
+  if (!serviceKey) {
+    return json({ error: "Server misconfigured" }, 500);
+  }
+  const admin = createClient(supabaseUrl, serviceKey);
+
+  const { data: event, error: fetchErr } = await admin
+    .from("events")
+    .select("id, link, status, event_date, recording_status")
+    .eq("id", eventId)
+    .eq("status", "approved")
+    .maybeSingle();
+
+  if (fetchErr) {
+    return json({ error: "Lookup failed" }, 500);
+  }
+  if (!event) {
+    return json({ error: "Event not found" }, 404);
+  }
+  if (event.recording_status === "approved") {
+    return json({ error: "Recording already approved" }, 409);
+  }
+  if (event.link && event.link === recordingUrl) {
+    return json({ error: "That's the event page, not a recording" }, 400);
+  }
+
+  const { error: updateErr } = await admin
+    .from("events")
+    .update({ recording_url: recordingUrl, recording_status: "pending" })
+    .eq("id", eventId)
+    .neq("recording_status", "approved");
+
+  if (updateErr) {
+    return json({ error: "Update failed" }, 500);
+  }
+
+  return json({ ok: true }, 200);
+});

--- a/supabase/migrations/20260419120000-add-event-recording-columns.sql
+++ b/supabase/migrations/20260419120000-add-event-recording-columns.sql
@@ -1,0 +1,57 @@
+-- Add recording_url + recording_status to events for user-submitted video recordings.
+-- Submissions flow through the submit-recording Edge Function (service-role),
+-- which enforces URL allowlisting, duplicate-of-event-link checks, and
+-- "already-approved" guards. Admin approves by flipping recording_status to
+-- 'approved' via the Supabase dashboard.
+
+ALTER TABLE public.events
+  ADD COLUMN recording_url text,
+  ADD COLUMN recording_status text;
+
+-- Enum-like gate on status values. CHECK passes on NULL by default; the explicit
+-- IS NULL branch is documentation.
+ALTER TABLE public.events
+  ADD CONSTRAINT events_recording_status_check
+  CHECK (recording_status IS NULL OR recording_status IN ('pending', 'approved'));
+
+-- Paired nullability: either both fields are set, or neither.
+ALTER TABLE public.events
+  ADD CONSTRAINT events_recording_consistency_check
+  CHECK (
+    (recording_status IS NULL AND recording_url IS NULL)
+    OR (recording_status IS NOT NULL AND recording_url IS NOT NULL)
+  );
+
+-- Server-side URL shape guard. Client + Edge Function validation is advisory;
+-- this is binding.
+ALTER TABLE public.events
+  ADD CONSTRAINT events_recording_url_format_check
+  CHECK (
+    recording_url IS NULL
+    OR (length(recording_url) BETWEEN 1 AND 2000 AND recording_url ~* '^https?://')
+  );
+
+-- Hot-path index: default /past view filters on approved recordings + date sort.
+CREATE INDEX events_approved_recordings_idx
+  ON public.events (event_date DESC)
+  WHERE recording_status = 'approved' AND recording_url IS NOT NULL;
+
+-- Secondary index: admin queue ("show me pending submissions").
+CREATE INDEX events_pending_recordings_idx
+  ON public.events (event_date DESC)
+  WHERE recording_status = 'pending';
+
+-- All recording writes go through the submit-recording Edge Function using the
+-- service-role key. The frontend (anon key) has no legitimate reason to UPDATE
+-- this table. Revoke to close the anon-can-mutate-any-column surface area.
+REVOKE UPDATE ON public.events FROM anon;
+
+-- ROLLBACK (manual, forward-only convention):
+-- GRANT UPDATE ON public.events TO anon;  -- only if it was granted before
+-- DROP INDEX IF EXISTS public.events_pending_recordings_idx;
+-- DROP INDEX IF EXISTS public.events_approved_recordings_idx;
+-- ALTER TABLE public.events DROP CONSTRAINT IF EXISTS events_recording_url_format_check;
+-- ALTER TABLE public.events DROP CONSTRAINT IF EXISTS events_recording_consistency_check;
+-- ALTER TABLE public.events DROP CONSTRAINT IF EXISTS events_recording_status_check;
+-- ALTER TABLE public.events DROP COLUMN IF EXISTS recording_status;
+-- ALTER TABLE public.events DROP COLUMN IF EXISTS recording_url;

--- a/tests/pastEvents.test.ts
+++ b/tests/pastEvents.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect } from 'vitest';
+import { todayInDenver, isPastEvent } from '../src/utils/pastEvents';
+
+describe('todayInDenver', () => {
+  it('returns yyyy-mm-dd format', () => {
+    const date = new Date('2026-04-19T12:00:00Z'); // noon UTC, 6am MDT
+    expect(todayInDenver(date)).toBe('2026-04-19');
+  });
+
+  it('returns Mountain Time date at 9pm MDT (prevents UTC day-rollover bug)', () => {
+    // 2026-04-20 03:00 UTC = 2026-04-19 21:00 MDT (Utah is still April 19)
+    const date = new Date('2026-04-20T03:00:00Z');
+    expect(todayInDenver(date)).toBe('2026-04-19');
+  });
+
+  it('correctly rolls to next day at midnight MDT', () => {
+    // 2026-04-20 06:00 UTC = 2026-04-20 00:00 MDT
+    const date = new Date('2026-04-20T06:00:00Z');
+    expect(todayInDenver(date)).toBe('2026-04-20');
+  });
+
+  it('handles DST spring-forward correctly', () => {
+    // 2026-03-08 is the second Sunday of March — DST begins 02:00 local.
+    // 2026-03-08 10:00 UTC = 04:00 MDT (post-DST).
+    const date = new Date('2026-03-08T10:00:00Z');
+    expect(todayInDenver(date)).toBe('2026-03-08');
+  });
+
+  it('handles DST fall-back correctly', () => {
+    // 2026-11-01 is the first Sunday of November — DST ends 02:00 local.
+    // 2026-11-01 10:00 UTC = 03:00 MST (post-fallback).
+    const date = new Date('2026-11-01T10:00:00Z');
+    expect(todayInDenver(date)).toBe('2026-11-01');
+  });
+});
+
+describe('isPastEvent', () => {
+  it('yesterday is past', () => {
+    expect(isPastEvent({ event_date: '2026-04-18' }, '2026-04-19')).toBe(true);
+  });
+
+  it('today is NOT past (excluded)', () => {
+    expect(isPastEvent({ event_date: '2026-04-19' }, '2026-04-19')).toBe(false);
+  });
+
+  it('tomorrow is NOT past', () => {
+    expect(isPastEvent({ event_date: '2026-04-20' }, '2026-04-19')).toBe(false);
+  });
+});

--- a/tests/recordingUrl.test.ts
+++ b/tests/recordingUrl.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import { isValidRecordingUrl, parseRecordingHostname } from '../src/utils/recordingUrl';
+
+describe('isValidRecordingUrl', () => {
+  it('accepts youtube.com watch URL', () => {
+    expect(isValidRecordingUrl('https://youtube.com/watch?v=abc123')).toBe(true);
+  });
+
+  it('accepts www.youtube.com', () => {
+    expect(isValidRecordingUrl('https://www.youtube.com/watch?v=abc')).toBe(true);
+  });
+
+  it('accepts youtu.be short URL', () => {
+    expect(isValidRecordingUrl('https://youtu.be/abc123')).toBe(true);
+  });
+
+  it('accepts vimeo.com', () => {
+    expect(isValidRecordingUrl('https://vimeo.com/12345')).toBe(true);
+  });
+
+  it('accepts player.vimeo.com embed URL', () => {
+    expect(isValidRecordingUrl('https://player.vimeo.com/video/12345')).toBe(true);
+  });
+
+  it('accepts loom.com', () => {
+    expect(isValidRecordingUrl('https://www.loom.com/share/abc')).toBe(true);
+  });
+
+  it('rejects http (non-https)', () => {
+    expect(isValidRecordingUrl('http://youtube.com/watch?v=abc')).toBe(false);
+  });
+
+  it('rejects Unicode-homograph hosts', () => {
+    // "youtübe.com" — U+00FC. new URL() punycodes this; allowlist rejects.
+    expect(isValidRecordingUrl('https://youtübe.com/watch?v=abc')).toBe(false);
+  });
+
+  it('rejects non-allowlisted hosts', () => {
+    expect(isValidRecordingUrl('https://notavideohost.com/watch')).toBe(false);
+  });
+
+  it('rejects javascript: protocol', () => {
+    expect(isValidRecordingUrl('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects data: URLs', () => {
+    expect(isValidRecordingUrl('data:text/html,hi')).toBe(false);
+  });
+
+  it('rejects file: URLs', () => {
+    expect(isValidRecordingUrl('file:///etc/passwd')).toBe(false);
+  });
+
+  it('rejects empty string', () => {
+    expect(isValidRecordingUrl('')).toBe(false);
+  });
+
+  it('rejects URLs > 2000 chars', () => {
+    const long = 'https://youtube.com/watch?v=' + 'a'.repeat(2000);
+    expect(isValidRecordingUrl(long)).toBe(false);
+  });
+
+  it('rejects malformed URL', () => {
+    expect(isValidRecordingUrl('not a url')).toBe(false);
+  });
+});
+
+describe('parseRecordingHostname', () => {
+  it('strips www prefix', () => {
+    expect(parseRecordingHostname('https://www.youtube.com/foo')).toBe('youtube.com');
+  });
+
+  it('returns null for null input', () => {
+    expect(parseRecordingHostname(null)).toBeNull();
+  });
+
+  it('returns null for malformed URL', () => {
+    expect(parseRecordingHostname('not a url')).toBeNull();
+  });
+
+  it('returns hostname for youtu.be', () => {
+    expect(parseRecordingHostname('https://youtu.be/abc')).toBe('youtu.be');
+  });
+});

--- a/tests/scraperFieldLists.test.ts
+++ b/tests/scraperFieldLists.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Regression guard: scrapers must never write to recording_url or recording_status.
+// Those columns hold user-submitted video links; re-scraping would clobber them.
+// See docs/plans/2026-04-19-002-feat-past-events-video-recordings-plan.md.
+const SCRAPER_FILES = [
+  'supabase/functions/scrape-meetup-events/index.ts',
+  'supabase/functions/scrape-single-meetup/index.ts',
+  'supabase/functions/scrape-university-events/index.ts',
+  'supabase/functions/scrape-misc-websites/index.ts',
+];
+
+const FORBIDDEN = ['recording_url', 'recording_status'];
+
+// Strip comments (// and /* */) so the DO-NOT-add reminder comments pass.
+function stripComments(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .map((line) => line.replace(/\/\/.*$/, ''))
+    .join('\n');
+}
+
+describe('scraper field lists', () => {
+  for (const relPath of SCRAPER_FILES) {
+    it(`${relPath} does not assign recording columns`, () => {
+      const src = stripComments(readFileSync(join(process.cwd(), relPath), 'utf-8'));
+      for (const key of FORBIDDEN) {
+        expect(src, `${key} must not appear in ${relPath}`).not.toContain(key);
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- New `/past` route listing past events, with a modal that lets anyone submit a YouTube/Vimeo/Loom recording link for a given event.
- Submissions flow through a new `submit-recording` Edge Function (service-role key, host allowlist, URL shape + duplicate + already-approved guards) and land pending until an admin approves via the Supabase dashboard.
- Default view shows approved recordings only; a toggle reveals all past events so contributors can fill gaps.

## Changes
- **Migration** `20260419120000-add-event-recording-columns.sql`: adds `recording_url` + `recording_status` to `events` with CHECK constraints (enum, consistency, URL shape), two partial indexes, and REVOKEs anon `UPDATE` (writes route through the Edge Function).
- **Edge Function** `submit-recording`: validates UUID, https-only, host allowlist, length, event state, duplicate-of-event-link, and already-approved cases.
- **Frontend**: `Past.tsx`, `PastEventsTimeline` (mirrors existing card style), `SubmitRecordingModal` with honeypot + time-to-submit gate + optimistic React Query cache update + sync double-submit guard + cancelable close-reset + mounted-ref gate.
- Timezone-correct "past" cutoff via `Intl.DateTimeFormat` with `America/Denver` (prevents UTC day-rollover bug at 9pm MDT).
- Scrapers: defensive comments + regression test asserting recording columns never appear in scraper `eventData` objects.

## Test plan
- [ ] `npm run lint`
- [ ] `npm test` (includes `tests/pastEvents.test.ts`, `tests/recordingUrl.test.ts`, `tests/scraperFieldLists.test.ts`)
- [ ] Apply migration in Supabase (staging) and verify CHECK constraints reject bad rows
- [ ] Deploy `submit-recording` Edge Function and submit a recording from `/past`; confirm row lands as `pending`
- [ ] Approve a recording via Supabase dashboard; confirm it appears in the default `/past` view
- [ ] Verify YouTube/Vimeo/Loom URLs accept; other hosts reject
- [ ] Verify duplicate submission and already-approved guards return clean errors
- [ ] Check "past" cutoff at ~9pm MDT (should not include today's still-upcoming events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)